### PR TITLE
Schedule Halide functions by internal name

### DIFF
--- a/examples/halide/timing_prefix.h
+++ b/examples/halide/timing_prefix.h
@@ -3,6 +3,9 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <map>
+#include <string>
+
 // How many times to run (and take min)
 // #define AUTOTUNE_TRIALS 3
 


### PR DESCRIPTION
The autotuner now builds a map of Halide-internal name to function object
which it uses to access functions by Halide name for scheduling. This
avoids the problem of requiring names used by the tuner to all be visible
as in-scope C objects pointing to the corresponding Func at the
AUTOTUNE_HOOK point.

NOTE: this requires an up-to-date copy of Halide for access to the `find_transitive_calls` function.
