### PR TITLE
[NEEDS CODEREVIEW] Generation of random composable-techniques/bandits 

### DIFF
--- a/opentuner/search/bandittechniques.py
+++ b/opentuner/search/bandittechniques.py
@@ -1,11 +1,12 @@
 import abc
+import copy
 import logging
 import math
 import random
 from collections import deque
 
 from .metatechniques import MetaSearchTechnique
-from .technique import register, SearchTechnique
+from .technique import register, SearchTechnique, all_techniques, get_random_generator_technique
 
 log = logging.getLogger(__name__)
 
@@ -157,6 +158,42 @@ class AUCBanditMetaTechnique(MetaSearchTechnique):
   def on_technique_no_desired_result(self, technique):
     """treat not providing a configuration as not a best"""
     self.bandit.on_result(technique.name, 0)
+
+  @classmethod
+  def generate_technique(cls, manipulator=None, num_techniques=5, retry_count=3, generator_weight=10, *args, **kwargs):
+    """
+    Generate a bandit by randomly selecting existing techniques or composable techniques.
+    If a composable technique is selected, the operators are then chosen
+
+    :param manipulator: a ConfigurationManipulator used to enumerate parameters
+    :param num_techniques: max number of subtechniques in the bandit
+    :param retry_count: number of times to try getting a new technique before giving up
+    :param generator_weight: weight to increase probability of choosing to generate a technique
+    """
+    techniques, generators = all_techniques()
+
+    # get set of parameters to consider
+    paramset = set()
+    for p in manipulator.params:
+      paramset.add(type(p))
+
+    # filter techniques to get rid of metatechniques
+    basetechniques = [t for t in techniques if not isinstance(t, MetaSearchTechnique)]
+    bandit_techniques = []
+    for i in range(num_techniques):
+      for j in range(retry_count):
+        # pick a technique or generate a composable
+        if random.random() < float(len(basetechniques)) / (len(basetechniques) + generator_weight*len(generators)):
+          candidate = copy.deepcopy(random.choice(basetechniques))
+        else:
+          # pick a random generator
+          candidate = get_random_generator_technique(generators, manipulator=manipulator)
+        if not (candidate.name in [t.name for t in bandit_techniques]):
+          bandit_techniques.append(candidate)
+          break
+
+    # make a bandit of the output list
+    return cls(bandit_techniques, name="GeneratedBandit", *args, **kwargs)
 
 
 class AUCBanditMutationTechnique(SearchTechnique):

--- a/opentuner/search/bandittechniques.py
+++ b/opentuner/search/bandittechniques.py
@@ -55,7 +55,7 @@ class BanditQueue(object):
     self.request_count += 1
     if log.isEnabledFor(logging.DEBUG) and (self.request_count % 1000) == 0:
       log.debug(str([
-          (t.name, self.exploitation_term(t), self.C * self.exploration_term(t))
+          (t, self.exploitation_term(t), self.C * self.exploration_term(t))
           for t in keys]))
 
     return reversed(keys)
@@ -253,7 +253,7 @@ register(AUCBanditMetaTechnique([
         evolutionarytechniques.GA(crossover = 'op3_cross_CX', mutation_rate=0.01, crossover_rate=0.8),
         evolutionarytechniques.GA(crossover = 'op3_cross_PX', mutation_rate=0.01, crossover_rate=0.8),
         evolutionarytechniques.GA(crossover = 'op3_cross_PMX', mutation_rate=0.01, crossover_rate=0.8),
-        evolutionarytechniques.UniformGreedyMutation(name='ga-base', mutation_rate=0.01)	
+        evolutionarytechniques.UniformGreedyMutation(name='ga-base', mutation_rate=0.01)
       ], name = "PSO_GA_Bandit"))
 register(AUCBanditMetaTechnique([
 	differentialevolution.DifferentialEvolutionAlt(),

--- a/opentuner/search/bandittechniques.py
+++ b/opentuner/search/bandittechniques.py
@@ -154,6 +154,9 @@ class AUCBanditMetaTechnique(MetaSearchTechnique):
   def on_technique_result(self, technique, result):
     self.bandit.on_result(technique.name, result.was_new_best)
 
+  def on_technique_no_desired_result(self, technique):
+    """treat not providing a configuration as not a best"""
+    self.bandit.on_result(technique.name, 0)
 
 
 class AUCBanditMutationTechnique(SearchTechnique):

--- a/opentuner/search/driver.py
+++ b/opentuner/search/driver.py
@@ -132,7 +132,7 @@ class SearchDriver(DriverBase):
                            tuning_run=self.tuning_run)
       else:
         dr = self.root_technique.desired_result()
-      if dr is None:
+      if dr is None or dr is False:
         log.debug("no desired result, skipping to testing phase")
         break
       self.session.flush()  # populate configuration_id

--- a/opentuner/search/manipulator.py
+++ b/opentuner/search/manipulator.py
@@ -343,6 +343,14 @@ class Parameter(object):
   def search_space_size(self):
     return 1
 
+  def op1_void(self, cfg):
+    """
+    The 'null' operator. Does nothing.
+
+    :param cfg: the configuration to be changed
+    """
+    pass
+
   # Stochastic variators
   def op3_swarm(self, cfg, cfg1, cfg2, c, c1, c2, *args, **kwargs):
     """
@@ -507,7 +515,7 @@ class PrimitiveParameter(Parameter):
 
 class NumericParameter(PrimitiveParameter):
   """
-  A parameter representing a number with a minimumm and maximum value
+  A parameter representing a number with a minimum and maximum value
   """
   def __init__(self, name, min_value, max_value, **kwargs):
     """min/max are inclusive"""
@@ -585,9 +593,6 @@ class NumericParameter(PrimitiveParameter):
       return 2 ** 32
     else:
       return self.max_value - self.min_value + 1  # inclusive range
-
-  def sv_mutate(self, cfg, mchoice='op1_normal_mutation', *args, **kwargs):
-    getattr(self, mchoice)(cfg, *args, **kwargs)
 
 
 class IntegerParameter(NumericParameter):
@@ -855,9 +860,6 @@ class ComplexParameter(Parameter):
     if not self.same_value(cfg_b, cfg_c):
       self.op1_randomize(cfg_dst)
 
-  def sv_mutate(self, cfg, mchoice='op1_randomize', *args, **kwargs):
-    getattr(self, mchoice)(cfg, *args, **kwargs)
-
   @abc.abstractmethod
   def op1_randomize(self, config):
     """
@@ -989,9 +991,6 @@ class EnumParameter(ComplexParameter):
   def search_space_size(self):
     return max(1, len(self.options))
 
-  def sv_mutate(self, cfg, *args, **kwargs):
-    self.op1_randomize(cfg)
-
 
 class PermutationParameter(ComplexParameter):
   """
@@ -1040,10 +1039,6 @@ class PermutationParameter(ComplexParameter):
 
   def search_space_size(self):
     return math.factorial(max(1, len(self._items)))
-
-  # Stochastic Variator
-  def sv_mutate(self, cfg, mchoice='op2_random_swap', *args, **kwargs):
-    getattr(self, mchoice)(cfg, cfg, *args, **kwargs)
 
   def op3_cross(self, cfg, cfg1, cfg2, xchoice='op3_cross_OX1', strength=0.3,
                 *args, **kwargs):
@@ -1650,10 +1645,6 @@ class FloatArray(Array):
     self.set_value(cfg, p)
     return vs
 
-  def sv_mutate(self, dest, *args, **kwargs):
-    # TODO
-    pass
-
 
 ##################
 
@@ -1704,9 +1695,9 @@ def operators(param, num_parents):
   Return a list of operators for the given parameter that take the specified
   number of input configurations
 
+  :param param: a Parameter class
   :param num_parents: a String specifying number of inputs required by the operator.
     should be one of '1', '2', '3', '4', or 'n'
-  :param param: a Parameter class
   """
   ops = []
   methods = inspect.getmembers(param, inspect.ismethod)
@@ -1727,7 +1718,6 @@ def is_operator(name, num_parents):
     should be one of '1', '2', '3', '4', or 'n'
   """
   return ('op' + num_parents + '_') == name[:4]
-
 
 def all_operators():
   """

--- a/opentuner/search/metatechniques.py
+++ b/opentuner/search/metatechniques.py
@@ -38,6 +38,9 @@ class MetaSearchTechnique(SearchTechniqueBase):
     for technique in techniques:
       dr = technique.desired_result()
       if dr is not None:
+        if dr is False:
+          # technique is waiting for results
+          continue
         self.driver.register_result_callback(dr,
             lambda result: self.on_technique_result(technique, result))
         if self.log_freq:
@@ -45,7 +48,13 @@ class MetaSearchTechnique(SearchTechniqueBase):
           self.debug_log()
         self.request_count += 1
         return dr
+      else:
+        self.on_technique_no_desired_result(technique)
     return None
+
+  def on_technique_no_desired_result(self, technique):
+    """called if a sub-technique returns None"""
+    pass
 
   def on_technique_result(self, technique, result):
     """callback for results of sub-techniques"""

--- a/opentuner/search/technique.py
+++ b/opentuner/search/technique.py
@@ -1,11 +1,14 @@
 import abc
-import sys
-import os
+import argparse
 import logging
+import os
+import random
+import sys
+
 from importlib import import_module
 from datetime import datetime
-import argparse
 from fn import _
+
 from opentuner.resultsdb.models import *
 from plugin import SearchPlugin
 
@@ -17,6 +20,8 @@ argparser.add_argument('--technique','-t', action='append',
                        help="which technique to use")
 argparser.add_argument('--list-techniques','-lt', action='store_true',
                        help="list techniques available and exit")
+argparser.add_argument('--generate-bandit-technique','-gbt', action='store_true',
+                       help="randomly generate a bandit to use")
 
 class SearchTechniqueBase(object):
   """
@@ -112,6 +117,11 @@ class SearchTechnique(SearchPlugin, SearchTechniqueBase):
   def handle_requested_result(self, result):
     """called for each new Result(), regardless of who requested it"""
     pass
+
+  @classmethod
+  def generate_technique(cls, manipulator=None, *args, **kwargs):
+    """ return a new technique based off this instance """
+    return cls(*args, **kwargs)
 
 class PureRandom(SearchTechnique):
   """
@@ -221,31 +231,71 @@ class SequentialSearchTechnique(AsyncProceduralSearchTechnique):
 #list of all techniques
 the_registry = list()
 
+#list of technique generators
+the_generator_registry = list()
 
 def register(t):
   the_registry.append(t)
 
+def register_generator(cls, generator_weight=1.0, *args, **kwargs):
+  """
+  register a technique generator - a tuple of (technique class, args, kwargs)
+  where args and kwargs will be passed into the generate_technique classmethod -
+  with specified probability weight when randomly choosing a generator
+
+  :param cls: a technique class to use as a generator
+  :param generator_weight: probability weighting when randomly choosing a generator
+  :param args: arguments to pass into generate_technique class method
+  :param kwargs: arguments to pass into generate_technique class method
+  """
+  the_generator_registry.append(((cls, args, kwargs), generator_weight))
+
 register(PureRandom())
 
+def get_random_generator_technique(generators=None, manipulator=None):
+  """
+  Takes in a sequence of ((generator, args, kwargs), weight) tuples.
+  Returns a random generated technique info tuple
 
-def all_techniques(args):
+  :param generators: optional argument to avoid repeated getting of generators
+  :param manipulator: manipulator to pass to generate_technique class method.
+  """
+  if generators is None:
+    techniques, generators = all_techniques()
+  g, args, kwargs = weighted_choice(generators)
+  return g.generate_technique(manipulator, *args, **kwargs)
+
+
+def weighted_choice(choices):
+  """ takes in a sequence of (choice, weight) tuples and randomly returns one """
+  total = sum(w for c, w in choices)
+  r = random.uniform(0, total)
+  upto = 0
+  for c, w in choices:
+    upto += w
+    if upto > r:
+      return c
+  return random.choice([c for c, w in choices])
+
+
+def all_techniques():
   #import all modules in search to ensure techniques are Registered
   for f in sorted(os.listdir(os.path.dirname(__file__))):
     m = re.match(r'^(.*)[.]py$', f)
     if m:
       import_module('opentuner.search.'+m.group(1))
 
-  return the_registry
-
+  return the_registry, the_generator_registry
 
 def get_enabled(args):
-  techniques = all_techniques(args)
+  techniques, generators = all_techniques()
   if args.list_techniques:
     for t in techniques:
       print t.name
     sys.exit(0)
 
   if not args.technique:
+    # no techniques specified, default technique
     args.technique = ['AUCBanditMetaTechniqueA']
 
   for unknown in set(args.technique) - set(map(_.name, techniques)):
@@ -253,7 +303,6 @@ def get_enabled(args):
     raise Exception('Unknown technique: --technique={}'.format(unknown))
 
   return [t for t in techniques if t.name in args.technique]
-
 
 def get_root(args):
   from metatechniques import RoundRobinMetaSearchTechnique

--- a/opentuner/search/technique.py
+++ b/opentuner/search/technique.py
@@ -75,10 +75,15 @@ class SearchTechnique(SearchPlugin, SearchTechniqueBase):
     driver.add_plugin(self)
 
   def desired_result(self):
-    """create and return a resultsdb.models.DesiredResult"""
+    """
+    create and return a resultsdb.models.DesiredResult
+    returns None if no desired results and False if waiting for results
+    """
     cfg = self.desired_configuration()
     if cfg is None:
       return None
+    if cfg is False:
+      return False
     if type(cfg) is Configuration:
       config = cfg
     else:
@@ -99,6 +104,8 @@ class SearchTechnique(SearchPlugin, SearchTechniqueBase):
     """
     return a cfg that we should test
     given a ConfigurationManipulator and SearchDriver
+    return None if there are no configurations to test
+    return False if waiting for results
     """
     return dict()
 
@@ -144,7 +151,7 @@ class AsyncProceduralSearchTechnique(SearchTechnique):
     to request tests and call driver.get_results() to read the results
 
     in AsyncProceduralSearchTechnique results are ready at an undefined
-    time (`yield None` to stall and wait for them)
+    time (`yield False` to stall and wait for them)
 
     in SequentialSearchTechnique results are ready after the yield
     """
@@ -209,7 +216,7 @@ class SequentialSearchTechnique(AsyncProceduralSearchTechnique):
                                     self.pending_tests)
         if self.pending_tests:
           self.rounds_since_novel_request = 0
-          yield None # wait
+          yield False # wait
 
 #list of all techniques
 the_registry = list()

--- a/tests/test_technique.py
+++ b/tests/test_technique.py
@@ -58,12 +58,12 @@ class ComposableSearchTechniqueTests(unittest.TestCase):
 
   def test_get_default_oeprator(self):
     default = self.technique.get_default_operator(manipulator.PermutationParameter)
-    self.assertDictEqual(default, {'op_name': 'op1_void', 'args': [], 'kwargs': {}})
+    self.assertDictEqual(default, {'op_name': 'op1_nop', 'args': [], 'kwargs': {}})
 
 
   def test_get_operator(self):
     default = self.technique.get_operator(manipulator.IntegerParameter)
-    self.assertDictEqual(default, {'op_name': 'op1_void', 'args': [], 'kwargs': {}})
+    self.assertDictEqual(default, {'op_name': 'op1_nop', 'args': [], 'kwargs': {}})
 
     default = self.technique.get_operator(manipulator.PermutationParameter)
     self.assertDictEqual(default, {'op_name': 'op3_cross','args': (),'kwargs': {'xchoice': 'op3_cross_CX'}})


### PR DESCRIPTION
Opening this so people can start looking over and commenting.

Main Changes:
 1. Generation of a bandit over a random set of techniques/generated-composable-techniques
   * option as -gbt or --generate-bandit-technique 
 2. Generation of composable techniques with random operators
 3. Differentiating when a technique has no desired results and when it is just waiting
   * allows metatechniques (i.e. bandit) to have behavior when a technique has no desired results
   * returning None means no desired results/cfgs
   * returning False means waiting
 4. Added a "reset" to SequentialSearchTechniques
   * if a SequentialSearchTechnique has not made any new requests (e.g. population has converged) over a threshold, the technique is reset by reinitializing the generator
 5. New "GreedyComposableTechnique"
   * mixes in global best result 
 
