### PR TITLE
Updating op1_void -> op1_nop

### DIFF
--- a/opentuner/search/composableevolutionarytechniques.py
+++ b/opentuner/search/composableevolutionarytechniques.py
@@ -370,7 +370,7 @@ class ComposableEvolutionaryTechnique(SequentialSearchTechnique):
     for param in paramset:
       operators = composable_operators(param, t.minimum_number_of_parents())
       # TODO - sometimes use "default" operator (don't choose an operator?
-      # TODO - lower chance of picking op1_void?
+      # TODO - lower chance of picking op1_nop?
       ComposableEvolutionaryTechnique.add_to_map(operator_map, param, random.choice(operators))
 
     t.set_operator_map(operator_map)

--- a/opentuner/search/manipulator.py
+++ b/opentuner/search/manipulator.py
@@ -343,7 +343,7 @@ class Parameter(object):
   def search_space_size(self):
     return 1
 
-  def op1_void(self, cfg):
+  def op1_nop(self, cfg):
     """
     The 'null' operator. Does nothing.
 


### PR DESCRIPTION
Missed due to weird behavior with git rebase -i and git commit --amend...

The comment showed up in a later commit.
Not sure what happened with the operator itself not changing...
