### PR TITLE
Extending data stored about tuning runs [codereview?]

### DIFF
--- a/opentuner/measurement/interface.py
+++ b/opentuner/measurement/interface.py
@@ -112,6 +112,7 @@ class MeasurementInterface(object):
         project=self.project_name(),
         name=self.program_name(),
         version=self.program_version(),
+        parameter_info=self.manipulator().parameters_to_json(),
     )
 
   def set_driver(self, measurement_driver):

--- a/opentuner/resultsdb/connect.py
+++ b/opentuner/resultsdb/connect.py
@@ -1,11 +1,13 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
-from models import Base
+from models import Base, _Meta
 import logging
 import time
 from pprint import pprint
 
 log = logging.getLogger(__name__)
+
+DB_VERSION = "0.0"
 
 if False:  # profiling of queries
   import atexit
@@ -32,9 +34,32 @@ if False:  # profiling of queries
 
 def connect(dbstr):
   engine = create_engine(dbstr, echo = False)
+  connection = engine.connect()
+
+  #handle case that the db was initialized before a version table existed yet
+  if engine.dialect.has_table(connection, "program"):
+    # if there are existing tables
+    if not engine.dialect.has_table(connection, "_meta"):
+      # if no version table, assume outdated db version and error
+      connection.close()
+      raise Exception("Your opentuner database is currently out of date. Save a back up and reinitialize")
+
+  # else if we have the table already, make sure version matches
+  if engine.dialect.has_table(connection, "_meta"):
+    Session = scoped_session(sessionmaker(autocommit=False,
+                                          autoflush=False,
+                                          bind=engine))
+    version = _Meta.get_version(Session)
+    if not DB_VERSION == version:
+      raise Exception("Your opentuner database version "+ version +" is out of date with the current version " + DB_VERSION)
+
   Base.metadata.create_all(engine)
+
   Session = scoped_session(sessionmaker(autocommit=False,
                                         autoflush=False,
                                         bind=engine))
+  # mark database with current version
+  _Meta.add_version(Session, DB_VERSION)
+
   return engine, Session
 


### PR DESCRIPTION
Added tracking of bandit hyperparameters and sub-techniques in a tuning run and augmented ProblemVersion with the representation being used (i.e. what parameters we are tuning on)

Also added a _Meta table to track/enforce database version (separate commit)

Will squash all the final commits after any fixes for issues/comments/suggestions.