### PR TITLE
Bugfixes: db versioning + op3_cross_PMX

### DIFF
--- a/opentuner/resultsdb/connect.py
+++ b/opentuner/resultsdb/connect.py
@@ -51,7 +51,7 @@ def connect(dbstr):
                                           bind=engine))
     version = _Meta.get_version(Session)
     if not DB_VERSION == version:
-      raise Exception("Your opentuner database version "+ version +" is out of date with the current version " + DB_VERSION)
+      raise Exception('Your opentuner database version {} is out of date with the current version {}'.format(version, DB_VERSION))
 
   Base.metadata.create_all(engine)
 
@@ -60,6 +60,7 @@ def connect(dbstr):
                                         bind=engine))
   # mark database with current version
   _Meta.add_version(Session, DB_VERSION)
+  Session.commit()
 
   return engine, Session
 

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -37,9 +37,18 @@ class PermutationOperatorTests(unittest.TestCase):
         self.config2 = self.manipulator.seed_config()
         self.config3 = self.manipulator.seed_config()
 
+        # repeating values
+        self.config4 = self.manipulator.seed_config()
+        self.config5 = self.manipulator.seed_config()
+
+
         self.param1.set_value(self.config1, [0,1,2,3,4,5,6,7,8,9])
         self.param1.set_value(self.config2, [4,3,2,1,0,9,8,7,6,5])
         self.param1.set_value(self.config3, [1,0,4,2,7,9,5,3,6,8])
+
+        # repeating values
+        self.param1.set_value(self.config4, [1,2,3,4,2,3,4,3,4,4])
+        self.param1.set_value(self.config5, [4,2,4,3,3,1,3,4,2,4])
 
     @mock.patch('random.randint', side_effect=faked_random([1,6]))
     def test_op2_random_swap_1_6(self, randint_func):
@@ -66,7 +75,6 @@ class PermutationOperatorTests(unittest.TestCase):
         self.param1.op3_cross(self.cfg, self.config1, self.config3,
                                 xchoice='op3_cross_PMX', strength=0.5)
         self.assertEqual(self.param1.get_value(self.cfg),[1,0,4,2,7,5,6,3,8,9])
-
 
     @mock.patch('random.randint', side_effect=faked_random([5]))
     @mock.patch('random.uniform', side_effect=faked_random([0.4]))
@@ -112,6 +120,18 @@ class PermutationOperatorTests(unittest.TestCase):
         # cut = 0, d = 5
         self.param1.op3_cross_PMX(self.cfg, self.config1, self.config3, 5)
         self.assertEqual(self.param1.get_value(self.cfg),[1,0,4,2,7,5,6,3,8,9])
+
+    @mock.patch('random.randint', side_effect=faked_random([4]))
+    def test_op3_cross_PMX_dups(self, randint_func):
+        # cut = 4, d = 5
+        self.param1.op3_cross_PMX(self.cfg, self.config5, self.config4, 5)
+
+        # [4,2,4,3,3,1,3,4,2,4]
+        # [1,2,3,4,2,3,4,3,4,4]
+        # expected:
+        # [1,2,4,3,2,3,4,3,4,4]
+
+        self.assertEqual(self.param1.get_value(self.cfg), [1,2,4,3,2,3,4,3,4,4])
 
 
     @mock.patch('random.randint', side_effect=faked_random([5]))


### PR DESCRIPTION
Fix to minor database versioning bug (listing techniques without existing database created an empty _meta version table -> user had to delete the new empty database before starting tuning)

Test + fix for issue with op3_cross_PMX with repeated values
  