### PR TITLE
Bugfix: misnamed variable + infinite looping in op3_cross_CX

### DIFF
--- a/opentuner/search/composableevolutionarytechniques.py
+++ b/opentuner/search/composableevolutionarytechniques.py
@@ -430,7 +430,7 @@ class RandomThreeParentsComposableTechnique(ComposableEvolutionaryTechnique):
     ret_list = params[:self.must_mutate_count]
     for param in params[self.must_mutate_count:]:
       if random.random() < self.cr:
-        ret_list.append(k)
+        ret_list.append(param)
     return ret_list
 
   def get_default_operator(self, param_type):

--- a/opentuner/search/manipulator.py
+++ b/opentuner/search/manipulator.py
@@ -1277,10 +1277,17 @@ class PermutationParameter(ComplexParameter):
 
     s = random.randint(0, len(p1) - 1)
     i = s
-    indices = []
-    while True:
-      indices.append(i)
-      i = p2.index(p1[i])
+    indices = set()
+
+    while len(indices) < len(p1): # should never exceed this
+      indices.add(i)
+      val = p1[i]
+      i = p2.index(val)
+      # deal with duplicate values
+      while i in indices:
+        if i == s:
+          break
+        i = p2[i+1:].index(val) + i + 1
       if i == s:
         break
 

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -142,6 +142,19 @@ class PermutationOperatorTests(unittest.TestCase):
         self.param1.op3_cross_CX(self.cfg, self.config1, self.config3, "unused")
         self.assertEqual(self.param1.get_value(self.cfg),[0,1,2,3,4,9,5,7,6,8])
 
+    @mock.patch('random.randint', side_effect=faked_random([0]))
+    def test_op3_cross_CX_dups(self, randint_func):
+        # initial replacement at index 4
+        self.param1.op3_cross_CX(self.cfg, self.config5, self.config4, "unused")
+
+        # [4,2,4,3,3,1,3,4,2,4]
+        # [1,2,3,4,2,3,4,3,4,4]
+        # expected:
+        # [1,2,3,4,3,3,4,4,2,4]
+
+        self.assertEqual(self.param1.get_value(self.cfg), [1,2,3,4,3,3,4,4,2,4])
+
+
     @mock.patch('random.randint', side_effect=faked_random([3]))
     def test_op3_cross_OX1_3_d4(self, randint_func):
         # cut at 3


### PR DESCRIPTION
deals with #61 

op3_cross_CX should now work with duplicate values, although behavior may deviate slightly in this case. The mapping from elements of first permutation to second permutation when determining a cycle is not fixed and depends on the order in which we find cycle elements.

For example, if the 2 permutations are...
p1 = 1,2,4,2\*, 3  (note the star is only to distinguish the 2s)
p2 = 2',1',2\*',4',3'  (note the ' is to distinguish between elements of p1 and p2)
if we start the cycle at the index 1, then 2 maps to 2'. If we start the cycle at index 3, then 2* maps to 2'.

