### PR TITLE
close thread pool after paralllel compilation

### DIFF
--- a/opentuner/measurement/driver.py
+++ b/opentuner/measurement/driver.py
@@ -201,6 +201,7 @@ class MeasurementDriver(DriverBase):
         except RuntimeError, e:
           print e
           # print 'Done!'
+      thread_pool.close()
     else:
       for dr in q.all():
         if self.claim_desired_result(dr):


### PR DESCRIPTION
Hey,
Opentuner crashes in one of my autotuning project when ThreadPool throws "can't create new thread". Calling `ThreadPool.close` after using it seems to fix the problem. Normally the close method is called by gc and it works fine only in some cases.