### PR TITLE
Refine execution flow for both sequential and parallel compilation

### DIFF
--- a/examples/gccflags/gccflags.py
+++ b/examples/gccflags/gccflags.py
@@ -76,7 +76,7 @@ class GccFlagsTuner(opentuner.measurement.MeasurementInterface):
       self.cc_bugs = (['-ftoplevel-reorder', '-fno-unit-at-a-time'], )
 
     self.result_list = {}
-    self.parallel_compile = args.parallel_compile
+    self.parallel_compile = True
     try:
       os.stat('./tmp')
     except OSError:

--- a/examples/gccflags/gccflags.py
+++ b/examples/gccflags/gccflags.py
@@ -76,7 +76,7 @@ class GccFlagsTuner(opentuner.measurement.MeasurementInterface):
       self.cc_bugs = (['-ftoplevel-reorder', '-fno-unit-at-a-time'], )
 
     self.result_list = {}
-    self.parallel_compile = True
+    self.parallel_compile = args.parallel_compile
     try:
       os.stat('./tmp')
     except OSError:
@@ -249,8 +249,10 @@ class GccFlagsTuner(opentuner.measurement.MeasurementInterface):
     tmp_dir = self.get_tmpdir(result_id)
     shutil.rmtree(tmp_dir)
 
-  def run(self, desired_result, input, limit):
-    pass
+  def compile_and_run(self, desired_result, input, limit):
+    cfg = desired_result.configuration.data
+    compile_result = self.compile(cfg, 0)
+    return self.run_precompiled(desired_result, input, limit, compile_result, 0)
 
   compile_results = {'ok': 0, 'timeout': 1, 'error': 2}
 

--- a/examples/gccflags/gccflags_minimal.py
+++ b/examples/gccflags/gccflags_minimal.py
@@ -48,14 +48,11 @@ class GccFlagsTuner(MeasurementInterface):
         IntegerParameter(param, min, max))
     return manipulator
 
-  def run(self, desired_result, input, limit):
+  def compile(self, cfg, id):
     """
-    Compile and run a given configuration then
-    return performance
+    Compile a given configuration in parallel
     """
-    cfg = desired_result.configuration.data
-
-    gcc_cmd = 'g++ apps/raytracer.cpp -o ./tmp.bin'
+    gcc_cmd = 'g++ apps/raytracer.cpp -o ./tmp' + str(id) + '.bin'
     gcc_cmd += ' -O{0}'.format(cfg['opt_level'])
     for flag in GCC_FLAGS:
       if cfg[flag] == 'on':
@@ -65,13 +62,27 @@ class GccFlagsTuner(MeasurementInterface):
     for param, min, max in GCC_PARAMS:
       gcc_cmd += ' --param {0}={1}'.format(
         param, cfg[param])
-
-    compile_result = self.call_program(gcc_cmd)
+    return self.call_program(gcc_cmd)
+  
+  def run_precompiled(self, desired_result, input, limit, compile_result, id):
+    """
+    Run a compile_result from compile() sequentially and return performance
+    """
     assert compile_result['returncode'] == 0
 
-    run_result = self.call_program('./tmp.bin')
+    run_result = self.call_program('./tmp' + str(id) + '.bin')
     assert run_result['returncode'] == 0
+    self.call_program('rm ./tmp' + str(id) + '.bin')
     return Result(time=run_result['time'])
+
+  def compile_and_run(self, desired_result, input, limit):
+    """
+    Compile and run a given configuration then
+    return performance
+    """
+    cfg = desired_result.configuration.data
+    compile_result = self.compile(cfg, 0)
+    return self.run_precompiled(desired_result, input, limit, compile_result, 0)
 
 if __name__ == '__main__':
   argparser = opentuner.default_argparser()

--- a/examples/gccflags/gccflags_minimal.py
+++ b/examples/gccflags/gccflags_minimal.py
@@ -52,7 +52,7 @@ class GccFlagsTuner(MeasurementInterface):
     """
     Compile a given configuration in parallel
     """
-    gcc_cmd = 'g++ apps/raytracer.cpp -o ./tmp' + str(id) + '.bin'
+    gcc_cmd = 'g++ apps/raytracer.cpp -o ./tmp{0}.bin'.format(id)
     gcc_cmd += ' -O{0}'.format(cfg['opt_level'])
     for flag in GCC_FLAGS:
       if cfg[flag] == 'on':
@@ -70,9 +70,13 @@ class GccFlagsTuner(MeasurementInterface):
     """
     assert compile_result['returncode'] == 0
 
-    run_result = self.call_program('./tmp' + str(id) + '.bin')
+    run_result = self.call_program('./tmp{0}.bin'.format(id))
     assert run_result['returncode'] == 0
-    self.call_program('rm ./tmp' + str(id) + '.bin')
+
+    try:    
+        self.call_program('rm ./tmp{0}.bin'.format(id))
+    finally:
+        pass
     return Result(time=run_result['time'])
 
   def compile_and_run(self, desired_result, input, limit):

--- a/examples/gccflags/gccflags_minimal.py
+++ b/examples/gccflags/gccflags_minimal.py
@@ -70,13 +70,12 @@ class GccFlagsTuner(MeasurementInterface):
     """
     assert compile_result['returncode'] == 0
 
-    run_result = self.call_program('./tmp{0}.bin'.format(id))
-    assert run_result['returncode'] == 0
-
     try:    
-        self.call_program('rm ./tmp{0}.bin'.format(id))
+        run_result = self.call_program('./tmp{0}.bin'.format(id))
+        assert run_result['returncode'] == 0
     finally:
-        pass
+        self.call_program('rm ./tmp{0}.bin'.format(id))
+
     return Result(time=run_result['time'])
 
   def compile_and_run(self, desired_result, input, limit):

--- a/opentuner/__init__.py
+++ b/opentuner/__init__.py
@@ -26,6 +26,7 @@ def argparsers():
   """
   return [
       measurement.driver.argparser,
+      measurement.interface.argparser,
       search.driver.argparser,
       search.plugin.argparser,
       search.technique.argparser,

--- a/opentuner/measurement/driver.py
+++ b/opentuner/measurement/driver.py
@@ -121,9 +121,13 @@ class MeasurementDriver(DriverBase):
 
     self.input_manager.before_run(desired_result, input)
 
-    result = self.interface.run_precompiled(desired_result, input,
-                                            desired_result.limit,
-                                            compile_result, exec_id)
+    if self.interface.parallel_compile:
+        result = self.interface.run_precompiled(desired_result, input,
+                                                desired_result.limit,
+                                                compile_result, exec_id)
+    else:
+        result = self.interface.compile_and_run(desired_result, input,
+                                                desired_result.limit)
 
     self.report_result(desired_result, result, input)
 

--- a/opentuner/measurement/interface.py
+++ b/opentuner/measurement/interface.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 
 argparser = argparse.ArgumentParser(add_help=False)
 argparser.add_argument('--parallel-compile', action='store_true',
-                       default='False',
+                       default=False,
                        help="present if compiling can be done in parallel")
 
 the_io_thread_pool = None

--- a/opentuner/measurement/interface.py
+++ b/opentuner/measurement/interface.py
@@ -57,26 +57,36 @@ class MeasurementInterface(object):
 
     self.pids = []
     self.pid_lock = threading.Lock()
-    self.parallel_compile = False
+    self.parallel_compile = args.parallel_compile
+    # If parallel_compile is False then compile_and_run() will be invoked
+    # sequentially otherwise the driver first invokes compile() in parallel
+    # followed by run_precompiled() sequentially
 
   def compile(self, config_data, id):
     """
-    Compiles according to the configuration in config_data (obtained from
-    desired_result.configuration) Should use id paramater to determine output
-    location of executable Return value will be passed to run_precompiled
-    as compile_result, useful for storing error/timeout information
+    Compile in PARALLEL according to the configuration in config_data 
+    (obtained from desired_result.configuration) Should use id parameter 
+    to determine output location of executable Return value will be passed 
+    to run_precompiled as compile_result, useful for storing error/timeout 
+    information
     """
+    if self.parallel_compile == True:
+        raise RuntimeError('MeasurementInterface.compile() not implemented for',
+                'parallel compilation')
     pass
 
   def run_precompiled(self, desired_result, input, limit, compile_result, id):
     """
-    Runs the given desired result on input and produce a Result() Abort
-    early if limit (in seconds) is reached Assumes that the executable
-    to be measured is already compiled in an executable corresponding to
-    identifier id compile_result is the return result of compile(), will be
-    None if compile was not called If id = None, must call run()
+    Run the given desired_result SEQUENTIALLY on input and produce a Result() 
+    Abort early if limit (in seconds) is reached Assume that the executable
+    to be measured has already been compiled to an executable corresponding to
+    identifier id by compile() The compile_result is the return result of compile(), 
+    and it will be None if compile() was not called
     """
-    return self.run(desired_result, input, limit)
+    if self.parallel_compile == True:
+        raise RuntimeError('MeasurementInterface.run_precompiled() not implemented', 
+                'for parallel compilation')
+    pass
 
   def cleanup(self, id):
     """
@@ -84,7 +94,18 @@ class MeasurementInterface(object):
     """
     pass
 
-  @abc.abstractmethod
+  #@abc.abstractmethod
+  def compile_and_run(self, desired_result, input, limit):
+    """
+    Compile and run the given desired_result on input and produce a 
+    Result(), abort early if limit (in seconds) is reached This function 
+    is only used for sequential execution flow
+
+    FIXME: Shoud uncomment @abc.abstractmethod Now comment out for
+    compatiability
+    """
+    return self.run(desired_result, input, limit)
+
   def run(self, desired_result, input, limit):
     """
     run the given desired_result on input and produce a Result(),

--- a/opentuner/measurement/interface.py
+++ b/opentuner/measurement/interface.py
@@ -71,7 +71,7 @@ class MeasurementInterface(object):
     to run_precompiled as compile_result, useful for storing error/timeout 
     information
     """
-    if self.parallel_compile == True:
+    if self.parallel_compile:
         raise RuntimeError('MeasurementInterface.compile() not implemented for',
                 'parallel compilation')
     pass
@@ -84,7 +84,7 @@ class MeasurementInterface(object):
     identifier id by compile() The compile_result is the return result of compile(), 
     and it will be None if compile() was not called
     """
-    if self.parallel_compile == True:
+    if self.parallel_compile:
         raise RuntimeError('MeasurementInterface.run_precompiled() not implemented', 
                 'for parallel compilation')
     pass

--- a/opentuner/measurement/interface.py
+++ b/opentuner/measurement/interface.py
@@ -28,6 +28,7 @@ log = logging.getLogger(__name__)
 
 argparser = argparse.ArgumentParser(add_help=False)
 argparser.add_argument('--parallel-compile', action='store_true',
+                       default='False',
                        help="present if compiling can be done in parallel")
 
 the_io_thread_pool = None


### PR DESCRIPTION
The purpose of this pull request is to totally separate the parallel compilation flow from the sequential compilation. Here is the updated scenario for users:

**Sequential (either one works):**
Option 1: Only implement compile_and_run().
Option 2: Implement compile() and run_precompiled(), and call these two functions in compile_and_run().

**Parallel:**
1. Implement compile() and run_precompiled().
2. Pass compile_and_run().
3. Run with "--parallel-compile". Parallel-compile will set "parallel-copmile=True".
4. Error out if either compile() or run_precompiled() is missing when "--parallel-compile" is specified.

**Main changes:**
1. Add compile_and_run() for sequential compilation.
   (The original run() was still there for compatibility, considering to remove it later.)
2. compile_and_run() will be invoked only when parallel_compile=False.
3. Based on 2, run_precompiled() doesn't have to call compile_and_run() anymore.
4. Based on 2 and 3, now the execution flow of sequential and parallel compilation are totally separated.
5. Both gccflag examples were also updated accordingly.
   (gccflag.py now supports sequential compilation which enforced parallel compilation before.)