### PR TITLE
Python 3 support (using future)

### DIFF
--- a/examples/gccflags/adddeps.py
+++ b/examples/gccflags/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/halide/adddeps.py
+++ b/examples/halide/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/hpl/adddeps.py
+++ b/examples/hpl/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/hpl/hpl.py
+++ b/examples/hpl/hpl.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import str
 import adddeps #fix sys.path
 
 import argparse
@@ -91,7 +93,7 @@ class HPLinpack(MeasurementInterface):
       '''
       called at the end of autotuning with the best resultsdb.models.Configuration
       '''
-      print "Final configuration", configuration.data
+      print("Final configuration", configuration.data)
             
 if __name__ == '__main__':
   args = parser.parse_args()

--- a/examples/mario/adddeps.py
+++ b/examples/mario/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/mario/mario.py
+++ b/examples/mario/mario.py
@@ -6,7 +6,13 @@ We write a movie file and ask the emulator to play it back while running
 fceux-hook.lua, which checks for death/flagpole and prints the fitness to
 stdout where OpenTuner, as the parent process, can read it.
 """
+from __future__ import division
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import adddeps #fix sys.path
 import argparse
 import base64
@@ -28,6 +34,7 @@ from opentuner.measurement import MeasurementInterface
 from opentuner.measurement.inputmanager import FixedInputManager
 from opentuner.tuningrunmain import TuningRunMain
 from opentuner.search.objective import MinimizeTime
+from future.utils import with_metaclass
 
 def instantiate(class_name):
   return getattr(sys.modules[__name__], class_name)()
@@ -45,12 +52,12 @@ def call_or_die(command, failmsg=None):
     stdout, stderr = p.communicate()
     return stdout, stderr, p.returncode
   except:
-    print "Failed to execute", command
+    print("Failed to execute", command)
     traceback.print_exc()
-    print "Child traceback:"
-    print sys.exc_info()[1].child_traceback
+    print("Child traceback:")
+    print(sys.exc_info()[1].child_traceback)
     if failmsg:
-      print failmsg
+      print(failmsg)
     sys.exit(1)
 
 # Functions for building FCEUX movie files (.fm2 files)
@@ -81,7 +88,7 @@ def fm2_lines(up, down, left, right, a, b, start, select, reset=set(), minFrame=
   if maxFrame is None:
     maxFrame = max(maxd(up, 0), maxd(down, 0), maxd(left, 0), maxd(right, 0), maxd(a, 0), maxd(b, 0), maxd(start, 0), maxd(select, 0), maxd(reset, 0)) + 1
   lines = list()
-  for i in xrange(minFrame, maxFrame):
+  for i in range(minFrame, maxFrame):
     lines.append(fm2_line(i in up, i in down, i in left, i in right, i in a, i in b, i in start, i in select, i in reset))
   return lines
 
@@ -131,17 +138,16 @@ def run_movie(fm2, args):
       display_numbers.append(display)
   match = re.search(r"^(won|died) (\d+) (\d+)$", stdout, re.MULTILINE)
   if not match:
-    print stderr
-    print stdout
+    print(stderr)
+    print(stdout)
     raise ValueError
   wl = match.group(1)
   x_pos = int(match.group(2))
   framecount = int(match.group(3))
   return (wl, x_pos, framecount)
 
-class Representation(object):
+class Representation(with_metaclass(abc.ABCMeta, object)):
   """Interface for pluggable tuning representations."""
-  __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
   def manipulator():
@@ -157,7 +163,7 @@ class NaiveRepresentation(Representation):
   """Uses a parameter per (button, frame) pair."""
   def manipulator(self):
     m = ConfigurationManipulator()
-    for i in xrange(0, 12000):
+    for i in range(0, 12000):
       m.add_parameter(BooleanParameter('L{}'.format(i)))
       m.add_parameter(BooleanParameter('R{}'.format(i)))
       m.add_parameter(BooleanParameter('D{}'.format(i)))
@@ -171,7 +177,7 @@ class NaiveRepresentation(Representation):
     down = set()
     running = set()
     jumping = set()
-    for i in xrange(0, 12000):
+    for i in range(0, 12000):
       if cfg['L{}'.format(i)]:
         left.add(i)
       if cfg['R{}'.format(i)]:
@@ -187,12 +193,12 @@ class NaiveRepresentation(Representation):
 class DurationRepresentation(Representation):
   def manipulator(self):
     m = ConfigurationManipulator()
-    for i in xrange(0, 1000):
+    for i in range(0, 1000):
       #bias 3:1 in favor of moving right
       m.add_parameter(EnumParameter('move{}'.format(i), ["R", "L", "RB", "LB", "N", "LR", "LRB", "R2", "RB2", "R3", "RB3"]))
       m.add_parameter(IntegerParameter('move_duration{}'.format(i), 1, 60))
       #m.add_parameter(BooleanParameter("D"+str(i)))
-    for i in xrange(0, 1000):
+    for i in range(0, 1000):
       m.add_parameter(IntegerParameter('jump_frame{}'.format(i), 0, 24000))
       m.add_parameter(IntegerParameter('jump_duration{}'.format(i), 1, 32))
     return m
@@ -203,28 +209,28 @@ class DurationRepresentation(Representation):
     down = set()
     running = set()
     start = 0
-    for i in xrange(0, 1000):
+    for i in range(0, 1000):
       move = cfg['move{}'.format(i)]
       move_duration = cfg['move_duration{}'.format(i)]
       if "R" in move:
-        right.update(xrange(start, start + move_duration))
+        right.update(list(range(start, start + move_duration)))
       if "L" in move:
-        left.update(xrange(start, start + move_duration))
+        left.update(list(range(start, start + move_duration)))
       if "B" in move:
-        running.update(xrange(start, start + move_duration))
+        running.update(list(range(start, start + move_duration)))
       start += move_duration
     jumping = set()
-    for i in xrange(0, 1000):
+    for i in range(0, 1000):
       jump_frame = cfg['jump_frame{}'.format(i)]
       jump_duration = cfg['jump_duration{}'.format(i)]
-      jumping.update(xrange(jump_frame, jump_frame + jump_duration))
+      jumping.update(list(range(jump_frame, jump_frame + jump_duration)))
     return left, right, down, running, jumping
 
 class AlphabetRepresentation(Representation):
   def manipulator(self):
     m = ConfigurationManipulator()
-    for i in xrange(0, 400*60):
-      m.add_parameter(EnumParameter('{}'.format(i), xrange(0, 16)))
+    for i in range(0, 400*60):
+      m.add_parameter(EnumParameter('{}'.format(i), list(range(0, 16))))
     return m
 
   def interpret(self, cfg):
@@ -233,7 +239,7 @@ class AlphabetRepresentation(Representation):
     down = set()
     running = set()
     jumping = set()
-    for i in xrange(0, 400*60):
+    for i in range(0, 400*60):
       bits = cfg[str(i)]
       if bits & 1:
         left.add(i)
@@ -247,9 +253,8 @@ class AlphabetRepresentation(Representation):
       #  down.add(i)
     return left, right, down, running, jumping
 
-class FitnessFunction(object):
+class FitnessFunction(with_metaclass(abc.ABCMeta, object)):
   """Interface for pluggable fitness functions."""
-  __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
   def __call__(won, x_pos, elapsed_frames):
@@ -267,7 +272,7 @@ class ProgressPlusTimeRemaining(FitnessFunction):
 
 class ProgressTimesAverageSpeed(FitnessFunction):
   def __call__(self, won, x_pos, elapsed_frames):
-    return -x_pos * (float(x_pos)/elapsed_frames)
+    return -x_pos * (old_div(float(x_pos),elapsed_frames))
 
 class SMBMI(MeasurementInterface):
   def __init__(self, args):
@@ -285,7 +290,7 @@ class SMBMI(MeasurementInterface):
       wl, x_pos, framecount = run_movie(fm2, self.args)
     except ValueError:
       return opentuner.resultsdb.models.Result(state='ERROR', time=float('inf'))
-    print wl, x_pos, framecount
+    print(wl, x_pos, framecount)
     return opentuner.resultsdb.models.Result(state='OK', time=self.args.fitness_function("won" in wl, x_pos, framecount))
 
   def run_precompiled(self, desired_result, input, limit, compile_result, id):
@@ -305,37 +310,37 @@ class SMBMI(MeasurementInterface):
 def new_bests_movie(args):
   stdout, stderr, returncode = call_or_die(["sqlite3", args.database, "select configuration_id from result where tuning_run_id = %d and was_new_best = 1 order by collection_date;" % args.tuning_run])
   if returncode:
-    print "Error retrieving new-best configurations:", stderr
+    print("Error retrieving new-best configurations:", stderr)
     sys.exit(1)
   cids = stdout.split()
-  print '\n'.join(fm2_smb_header())
+  print('\n'.join(fm2_smb_header()))
   for cid in cids:
     stdout, stderr, returncode = call_or_die(["sqlite3", args.database, "select quote(data) from configuration where id = %d;" % int(cid)])
     if returncode:
-      print "Error retriving configuration data:", cid, stderr
+      print("Error retriving configuration data:", cid, stderr)
       sys.exit(1)
     cfg = pickle.loads(zlib.decompress(base64.b16decode(stdout.strip()[2:-1])))
     left, right, down, running, jumping = args.representation.interpret(cfg)
     fm2 = fm2_smb(left, right, down, running, jumping)
     _, _, framecount = run_movie(fm2, args)
-    print fm2_smb(left, right, down, running, jumping, header=False, maxFrame=framecount)
+    print(fm2_smb(left, right, down, running, jumping, header=False, maxFrame=framecount))
 
 if __name__ == '__main__':
   args = argparser.parse_args()
   call_or_die(["fceux", "--help"], failmsg="Is fceux on your PATH?")
   if not args.headful:
     call_or_die(["xvfb-run", "--help"], failmsg="Is xvfb-run on your PATH? (or, pass --headful)")
-    for n in xrange(99, 99 + args.parallelism):
+    for n in range(99, 99 + args.parallelism):
       display_numbers.append(str(n))
   if args.tuning_run:
     call_or_die(["sqlite3", "-version"], failmsg="Is sqlite3 on your PATH?")
     if args.database is not None:
       new_bests_movie(args)
     else:
-      print "must specify --database"
+      print("must specify --database")
   else:
     if os.path.isfile('smb.nes'):
       SMBMI.main(args)
     else:
-      print "smb.nes not found"
+      print("smb.nes not found")
 

--- a/examples/petabricks/adddeps.py
+++ b/examples/petabricks/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/petabricks/import_old_result.py
+++ b/examples/petabricks/import_old_result.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import adddeps  # fix sys.path
 
 import argparse
@@ -106,7 +107,7 @@ def main(args):
         state='COMPLETE')
       session.add(desired_result)
       tuningrun.end_date = date
-      print gen, date, result.time
+      print(gen, date, result.time)
 
   session.commit()
 

--- a/examples/petabricks/pbtuner.py
+++ b/examples/petabricks/pbtuner.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+from __future__ import division
+from __future__ import print_function
+from builtins import range
+from past.utils import old_div
 import adddeps  # fix sys.path
 
 import re
@@ -63,11 +67,11 @@ class PetaBricksInterface(MeasurementInterface):
     r = dict()
 
     # direct copy
-    for k, v in cfg.iteritems():
+    for k, v in list(cfg.items()):
       if k[0] != '.':
         r[k] = v
 
-    for name, choices in self.choice_sites.items():
+    for name, choices in list(self.choice_sites.items()):
       param = self.manipulator.parameters_dict(cfg)['.' + name]
       lvl = 0
       for cutoff, choice in param.selector_iter(cfg):
@@ -81,8 +85,8 @@ class PetaBricksInterface(MeasurementInterface):
   def run(self, desired_result, input, limit):
     limit = min(limit, self.args.upper_limit)
     with tempfile.NamedTemporaryFile(suffix='.petabricks.cfg') as cfgtmp:
-      for k, v in self.build_config(desired_result.configuration.data).items():
-        print >> cfgtmp, k, '=', v
+      for k, v in list(self.build_config(desired_result.configuration.data).items()):
+        print(k, '=', v, file=cfgtmp)
       cfgtmp.flush()
       if args.program_input:
         input_opts = ['--iogen-run=' + args.program_input,
@@ -124,7 +128,7 @@ class PetaBricksInterface(MeasurementInterface):
     with open(args.program_cfg_output, 'w') as fd:
       cfg = self.build_config(configuration.data)
       for k, v in sorted(cfg.items()):
-        print >> fd, k, '=', v
+        print(k, '=', v, file=fd)
     log.info("final configuration written to %s", args.program_cfg_output)
 
   def manipulator(self):
@@ -160,10 +164,10 @@ class PetaBricksInterface(MeasurementInterface):
       else:
         manipulator.add_parameter(LogIntegerParameter(k, minval, maxval))
 
-    for name, choices in self.choice_sites.items():
+    for name, choices in list(self.choice_sites.items()):
       manipulator.add_parameter(
-        SelectorParameter('.' + name, range(choices + 1),
-                          upper_limit / choices))
+        SelectorParameter('.' + name, list(range(choices + 1)),
+                          old_div(upper_limit, choices)))
 
     self.manipulator = manipulator
     return manipulator

--- a/examples/py_api/adddeps.py
+++ b/examples/py_api/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/py_api/api_example.py
+++ b/examples/py_api/api_example.py
@@ -5,7 +5,9 @@ Examples usage of a Python API interface to opentuner.
 Unlike the other examples, this code lets the user control the main() of
 the program and calls into opentuner to get new configurations to test.
 """
+from __future__ import print_function
 
+from builtins import range
 import adddeps  # add opentuner to path in dev mode
 
 import opentuner
@@ -38,7 +40,7 @@ def main():
                                             program_name='api_test',
                                             program_version='0.1')
     api = TuningRunManager(interface, args)
-    for x in xrange(500):
+    for x in range(500):
         desired_result = api.get_next_desired_result()
         if desired_result is None:
           # The search space for this example is very small, so sometimes
@@ -51,7 +53,7 @@ def main():
 
     best_cfg = api.get_best_configuration()
     api.finish()
-    print 'best x found was', best_cfg['x']
+    print('best x found was', best_cfg['x'])
 
 if __name__ == '__main__':
   main()

--- a/examples/py_api/multiple_tuning_runs.py
+++ b/examples/py_api/multiple_tuning_runs.py
@@ -7,7 +7,10 @@ the program and calls into opentuner to get new configurations to test.
 
 This version runs multiple tuning runs at once in a single process.
 """
+from __future__ import print_function
 
+from builtins import zip
+from builtins import range
 import adddeps  # add opentuner to path in dev mode
 
 import opentuner
@@ -63,7 +66,7 @@ def main():
             create_test_tuning_run('sqlite:////tmp/b.db'),
             create_test_tuning_run('sqlite:////tmp/c.db')]
     test_funcs = [test_func1, test_func2, test_func3]
-    for x in xrange(100):
+    for x in range(100):
       for api, test_func in zip(apis, test_funcs):
         desired_result = api.get_next_desired_result()
         if desired_result is None:

--- a/examples/rosenbrock/adddeps.py
+++ b/examples/rosenbrock/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/rosenbrock/rosenbrock.py
+++ b/examples/rosenbrock/rosenbrock.py
@@ -8,6 +8,8 @@
 # http://en.wikipedia.org/wiki/Test_functions_for_optimization
 #
 
+from __future__ import print_function
+from builtins import range
 import adddeps  # fix sys.path
 
 import argparse
@@ -36,12 +38,12 @@ class Rosenbrock(MeasurementInterface):
     val = 0.0
     if self.args.function == 'rosenbrock':
       # the actual rosenbrock function:
-      for d in xrange(self.args.dimensions - 1):
+      for d in range(self.args.dimensions - 1):
         x0 = cfg[d]
         x1 = cfg[d + 1]
         val += 100.0 * (x1 - x0 ** 2) ** 2 + (x0 - 1) ** 2
     elif self.args.function == 'sphere':
-      for d in xrange(self.args.dimensions):
+      for d in range(self.args.dimensions):
         xi = cfg[d]
         val += xi ** 2
     elif self.args.function == 'beale':
@@ -56,7 +58,7 @@ class Rosenbrock(MeasurementInterface):
 
   def manipulator(self):
     manipulator = ConfigurationManipulator()
-    for d in xrange(self.args.dimensions):
+    for d in range(self.args.dimensions):
       manipulator.add_parameter(FloatParameter(d,
                                                -self.args.domain,
                                                self.args.domain))
@@ -72,7 +74,7 @@ class Rosenbrock(MeasurementInterface):
     """
     called at the end of autotuning with the best resultsdb.models.Configuration
     """
-    print "Final configuration", configuration.data
+    print("Final configuration", configuration.data)
 
 
 if __name__ == '__main__':

--- a/examples/tsp/adddeps.py
+++ b/examples/tsp/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/tsp/tsp.py
+++ b/examples/tsp/tsp.py
@@ -5,6 +5,7 @@
 # http://en.wikipedia.org/wiki/Travelling_salesman_problem
 #
 
+from builtins import range
 import adddeps #fix sys.path
 
 import argparse
@@ -44,7 +45,7 @@ class TSP(MeasurementInterface):
 
     def manipulator(self):
         manipulator = ConfigurationManipulator()
-        manipulator.add_parameter(PermutationParameter(0, range(len(self.distance))))
+        manipulator.add_parameter(PermutationParameter(0, list(range(len(self.distance)))))
         return manipulator
 
     def solution(self):

--- a/examples/tutorials/adddeps.py
+++ b/examples/tutorials/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/tutorials/mmm_tuner.py
+++ b/examples/tutorials/mmm_tuner.py
@@ -4,6 +4,7 @@
 #
 # This is an extremely simplified version meant only for tutorials
 #
+from __future__ import print_function
 import adddeps  # fix sys.path
 
 import opentuner
@@ -48,7 +49,7 @@ class GccFlagsTuner(MeasurementInterface):
 
   def save_final_config(self, configuration):
     """called at the end of tuning"""
-    print "Optimal block size written to mmm_final_config.json:", configuration.data
+    print("Optimal block size written to mmm_final_config.json:", configuration.data)
     self.manipulator().save_to_file(configuration.data,
                                     'mmm_final_config.json')
 

--- a/examples/unitary/adddeps.py
+++ b/examples/unitary/adddeps.py
@@ -1,4 +1,5 @@
 # we would prefer a symbolic link, but it does not work on windows
+from past.builtins import execfile
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')

--- a/examples/unitary/cla_func.py
+++ b/examples/unitary/cla_func.py
@@ -1,8 +1,14 @@
+from __future__ import division
+from __future__ import print_function
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import numpy as np
 import math
 
 
-class Op:
+class Op(object):
   def __init__(self):
     self.M = []
     self.name = [];
@@ -35,41 +41,41 @@ class Op:
     #self.anti_operator.append('+w');
 
     # Operators
-    alpha = math.pi / 3.0;
-    da = math.pi / 10.0;
+    alpha = old_div(math.pi, 3.0);
+    da = old_div(math.pi, 10.0);
 
     # operator 1 +z
     self.M.append(np.matrix(
-      [[math.cos(da / 2.0) - 1j * math.sin(da / 2.0), 0.0],
-       [0.0, math.cos(da / 2.0) + 1j * math.sin(da / 2.0)]]))
+      [[math.cos(old_div(da, 2.0)) - 1j * math.sin(old_div(da, 2.0)), 0.0],
+       [0.0, math.cos(old_div(da, 2.0)) + 1j * math.sin(old_div(da, 2.0))]]))
     self.name.append('+z');
     self.mutation_partners.append(['-z', '+w', '-w']);
     self.anti_operator.append('-z');
 
     # operator 2 -z
     self.M.append(np.matrix(
-      [[math.cos(-da / 2.0) - 1j * math.sin(-da / 2.0), 0.0],
-       [0.0, math.cos(-da / 2.0) + 1j * math.sin(-da / 2.0)]]))
+      [[math.cos(old_div(-da, 2.0)) - 1j * math.sin(old_div(-da, 2.0)), 0.0],
+       [0.0, math.cos(old_div(-da, 2.0)) + 1j * math.sin(old_div(-da, 2.0))]]))
     self.name.append('-z');
     self.mutation_partners.append(['+z', '+w', '-w']);
     self.anti_operator.append('+z');
 
     # operator 3 +w
     self.M.append(np.matrix([
-      [math.cos(da / 2.0) - 1j * math.cos(alpha) * math.sin(da / 2.0),
-       -math.sin(alpha) * math.sin(da / 2.0)],
-      [math.sin(alpha) * math.sin(da / 2.0),
-       math.cos(da / 2.0) + 1j * math.cos(alpha) * math.sin(da / 2.0)]]))
+      [math.cos(old_div(da, 2.0)) - 1j * math.cos(alpha) * math.sin(old_div(da, 2.0)),
+       -math.sin(alpha) * math.sin(old_div(da, 2.0))],
+      [math.sin(alpha) * math.sin(old_div(da, 2.0)),
+       math.cos(old_div(da, 2.0)) + 1j * math.cos(alpha) * math.sin(old_div(da, 2.0))]]))
     self.name.append('+w');
     self.mutation_partners.append(['+z', '-z', '-w']);
     self.anti_operator.append('-w');
 
     # operator 4 -w
     self.M.append(np.matrix([
-      [math.cos(-da / 2.0) - 1j * math.cos(alpha) * math.sin(-da / 2.0),
-       -math.sin(alpha) * math.sin(-da / 2.0)],
-      [math.sin(alpha) * math.sin(-da / 2.0),
-       math.cos(-da / 2.0) + 1j * math.cos(alpha) * math.sin(-da / 2.0)]]))
+      [math.cos(old_div(-da, 2.0)) - 1j * math.cos(alpha) * math.sin(old_div(-da, 2.0)),
+       -math.sin(alpha) * math.sin(old_div(-da, 2.0))],
+      [math.sin(alpha) * math.sin(old_div(-da, 2.0)),
+       math.cos(old_div(-da, 2.0)) + 1j * math.cos(alpha) * math.sin(old_div(-da, 2.0))]]))
     self.name.append('-w');
     self.mutation_partners.append(['+z', '-z', '+w']);
     self.anti_operator.append('+w');
@@ -80,8 +86,8 @@ class Op:
     # in case one isn't unitary the program stops
     for k in range(len(self.M)):
       if (np.trace(self.M[k] * self.M[k].getH()) - 2 != 0):
-        print "Operator " + self.name[k] + " (no. " + str(
-          k) + ") isn't unitary!"
+        print("Operator " + self.name[k] + " (no. " + str(
+          k) + ") isn't unitary!")
         exit()
 
   def determine_index_of_mutation_partners(self):
@@ -106,8 +112,8 @@ class Op:
           found_operator = True
 
       if found_operator == False:
-        print "Couldn't find the anti-operator for operator " + self.name[
-          k] + " (no " + str(k) + ")"
+        print("Couldn't find the anti-operator for operator " + self.name[
+          k] + " (no " + str(k) + ")")
 
   def __str__(self):
     # just a test to play around
@@ -136,7 +142,7 @@ def calc_fidelity(sequence, Op, Ugoal):
     Uapprox = Op.M[sequence[k]] * Uapprox
 
   # M.getH() returns the complex conjugate of self
-  result = (1.0 / len(Ugoal)) * abs(np.trace(Ugoal * Uapprox.getH()))
+  result = (old_div(1.0, len(Ugoal))) * abs(np.trace(Ugoal * Uapprox.getH()))
 
   return result
 

--- a/examples/unitary/input_generator.py
+++ b/examples/unitary/input_generator.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 import math
 import random
@@ -78,23 +81,23 @@ def my_cexp(x):
 
 
 def X_Mat(a):
-  return np.matrix([[math.cos(a / 2.0), -1j * math.sin(a / 2.0)],
-                    [-1j * math.sin(a / 2.0), math.cos(a / 2.0)]])
+  return np.matrix([[math.cos(old_div(a, 2.0)), -1j * math.sin(old_div(a, 2.0))],
+                    [-1j * math.sin(old_div(a, 2.0)), math.cos(old_div(a, 2.0))]])
 
 
 def Y_Mat(a):
-  return np.matrix([[math.cos(a / 2.0), -math.sin(a / 2.0)],
-                    [math.sin(a / 2.0), math.cos(a / 2.0)]])
+  return np.matrix([[math.cos(old_div(a, 2.0)), -math.sin(old_div(a, 2.0))],
+                    [math.sin(old_div(a, 2.0)), math.cos(old_div(a, 2.0))]])
 
 
 def Z_Mat(a):
-  return np.matrix([[math.cos(-a / 2.0) + 1j * math.sin(-a / 2.0), 0],
-                    [0, math.cos(a / 2.0) + 1j * math.sin(a / 2.0)]])
+  return np.matrix([[math.cos(old_div(-a, 2.0)) + 1j * math.sin(old_div(-a, 2.0)), 0],
+                    [0, math.cos(old_div(a, 2.0)) + 1j * math.sin(old_div(a, 2.0))]])
 
 
 def W_Mat(a, alpha):
-  return np.matrix([[math.cos(a / 2) - 1j * math.cos(alpha) * math.sin(a / 2.0),
-                     -math.sin(a / 2.0) * math.sin(alpha)],
-                    [math.sin(a / 2.0) * math.sin(alpha),
-                     math.cos(a / 2.0) + 1j * math.cos(alpha) * math.sin(
-                       a / 2.0)]])
+  return np.matrix([[math.cos(old_div(a, 2)) - 1j * math.cos(alpha) * math.sin(old_div(a, 2.0)),
+                     -math.sin(old_div(a, 2.0)) * math.sin(alpha)],
+                    [math.sin(old_div(a, 2.0)) * math.sin(alpha),
+                     math.cos(old_div(a, 2.0)) + 1j * math.cos(alpha) * math.sin(
+                       old_div(a, 2.0))]])

--- a/examples/unitary/unitary.py
+++ b/examples/unitary/unitary.py
@@ -10,6 +10,10 @@
 # Contributed by Clarice D. Aiello <clarice@mit.edu>
 #
 
+from __future__ import division
+from __future__ import print_function
+from builtins import range
+from past.utils import old_div
 import adddeps  # fix sys.path
 
 import argparse
@@ -21,7 +25,7 @@ import sys
 try:
   import numpy as np
 except:
-  print >> sys.stderr, '''
+  print('''
 
 ERROR: import numpy failed, please install numpy
 
@@ -30,7 +34,7 @@ Possible things to try:
   ../../venv/bin/easy_install numpy
   sudo apt-get install python-numpy
 
-'''
+''', file=sys.stderr)
   raise
 
 import opentuner
@@ -48,10 +52,10 @@ from opentuner.search.manipulator import (ConfigurationManipulator,
 
 
 def generate_random_Ugoal_FIXED(**kwargs):
-  Ag = -1 / sqrt(10);
-  Bg = sqrt(2) / sqrt(10);
-  Cg = -sqrt(3) / sqrt(10);
-  Dg = -sqrt(4) / sqrt(10);
+  Ag = old_div(-1, sqrt(10));
+  Bg = old_div(sqrt(2), sqrt(10));
+  Cg = old_div(-sqrt(3), sqrt(10));
+  Dg = old_div(-sqrt(4), sqrt(10));
   return cla_func.np.matrix(
     [[Ag + Cg * 1j, Bg + Dg * 1j], [-Bg + Dg * 1j, Ag - Cg * 1j]])
 
@@ -68,7 +72,7 @@ generators = {
 parser = argparse.ArgumentParser(parents=opentuner.argparsers())
 parser.add_argument('--seq-len', type=int, default=10,
                     help='maximum length for generated sequence')
-parser.add_argument('--goal-type', choices=generators.keys(), default='hard',
+parser.add_argument('--goal-type', choices=list(generators.keys()), default='hard',
                     help='method used to generate goal')
 parser.add_argument('--goal-n', type=int, default=100,
                     help='argument to ugoal generator')
@@ -90,7 +94,7 @@ class Unitary(opentuner.measurement.MeasurementInterface):
   def run(self, desired_result, input, limit):
     cfg = desired_result.configuration.data
 
-    sequence = [cfg[i] for i in xrange(self.args.seq_len)
+    sequence = [cfg[i] for i in range(self.args.seq_len)
                 if cfg[i] < self.num_operators]
     # sequence can be shorter than self.args.seq_len with null operator
 
@@ -106,7 +110,7 @@ class Unitary(opentuner.measurement.MeasurementInterface):
 
   def manipulator(self):
     manipulator = ConfigurationManipulator()
-    for d in xrange(self.args.seq_len):
+    for d in range(self.args.seq_len):
       # we add 1 to num_operators allow a ignored 'null' operator
       manipulator.add_parameter(SwitchParameter(d, self.num_operators + 1))
     return manipulator
@@ -116,9 +120,9 @@ class Unitary(opentuner.measurement.MeasurementInterface):
     called at the end of autotuning with the best resultsdb.models.Configuration
     '''
     cfg = configuration.data
-    sequence = [cfg[i] for i in xrange(self.args.seq_len)
+    sequence = [cfg[i] for i in range(self.args.seq_len)
                 if cfg[i] < self.num_operators]
-    print "Final sequence", sequence
+    print("Final sequence", sequence)
 
   def objective(self):
     # we could have also chosen to store 1.0 - accuracy in the time field

--- a/misc/livedisplay.py
+++ b/misc/livedisplay.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import os
 import argparse
 import subprocess
@@ -33,18 +34,18 @@ while '\n' not in open(args.details).read():
 
 p1 = subprocess.Popen(["gnuplot"], stdin=subprocess.PIPE)
 p1.stdin.write(open(args.gnuplot_filename).read())
-print >> p1.stdin, 'set title "Zoomed out"'
-print >> p1.stdin, "set xrange [0:%f]" % args.xrange
-print >> p1.stdin, "set yrange [0:%f]" % args.yrange2
+print('set title "Zoomed out"', file=p1.stdin)
+print("set xrange [0:%f]" % args.xrange, file=p1.stdin)
+print("set yrange [0:%f]" % args.yrange2, file=p1.stdin)
 p1.stdin.flush()
 
 time.sleep(1)
 
 p2 = subprocess.Popen(["gnuplot"], stdin=subprocess.PIPE)
 p2.stdin.write(open(args.gnuplot_filename).read())
-print >> p2.stdin, 'set title "Zoomed in"'
-print >> p2.stdin, "set xrange [0:%f]" % args.xrange
-print >> p2.stdin, "set yrange [0:%f]" % args.yrange
+print('set title "Zoomed in"', file=p2.stdin)
+print("set xrange [0:%f]" % args.xrange, file=p2.stdin)
+print("set yrange [0:%f]" % args.yrange, file=p2.stdin)
 p2.stdin.flush()
 
 procs = [p1, p2]
@@ -52,6 +53,6 @@ procs = [p1, p2]
 while True:
   time.sleep(1)
   for p in procs:
-    print >> p.stdin, "replot"
+    print("replot", file=p.stdin)
     p.stdin.flush()
 

--- a/opentuner/__init__.py
+++ b/opentuner/__init__.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 
-import measurement
-import resultsdb
-import search
-import tuningrunmain
+from . import measurement
+from . import resultsdb
+from . import search
+from . import tuningrunmain
 from opentuner.measurement import MeasurementInterface
 from opentuner.resultsdb.models import Configuration
 from opentuner.resultsdb.models import DesiredResult

--- a/opentuner/driverbase.py
+++ b/opentuner/driverbase.py
@@ -1,3 +1,4 @@
+from builtins import object
 from opentuner.resultsdb.models import *
 
 

--- a/opentuner/measurement/__init__.py
+++ b/opentuner/measurement/__init__.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 
-import driver
-import interface
-from interface import MeasurementInterface
-from driver import MeasurementDriver
+from . import driver
+from . import interface
+from .interface import MeasurementInterface
+from .driver import MeasurementDriver
 

--- a/opentuner/measurement/driver.py
+++ b/opentuner/measurement/driver.py
@@ -1,3 +1,7 @@
+from __future__ import division
+from __future__ import print_function
+from builtins import zip
+from past.utils import old_div
 import argparse
 import logging
 import time
@@ -54,8 +58,8 @@ class MeasurementDriver(DriverBase):
       m = Machine(name=hostname,
                   cpu=_cputype(),
                   cores=_cpucount(),
-                  memory_gb=_memorysize() / (
-                  1024.0 ** 3) if _memorysize() else 0,
+                  memory_gb=old_div(_memorysize(), (
+                  1024.0 ** 3)) if _memorysize() else 0,
                   machine_class=self.get_machine_class())
       self.session.add(m)
       return m
@@ -202,8 +206,8 @@ class MeasurementDriver(DriverBase):
         self.run_desired_result(dr, compile_result, dr.id)
         try:
           self.interface.cleanup(dr.id)
-        except RuntimeError, e:
-          print e
+        except RuntimeError as e:
+          print(e)
           # print 'Done!'
       thread_pool.close()
     else:

--- a/opentuner/measurement/inputmanager.py
+++ b/opentuner/measurement/inputmanager.py
@@ -1,13 +1,14 @@
+from builtins import object
 import abc
 import opentuner
 from opentuner.resultsdb.models import *
+from future.utils import with_metaclass
 
 
-class InputManager(object):
+class InputManager(with_metaclass(abc.ABCMeta, object)):
   """
   abstract base class for compile and measurement
   """
-  __metaclass__ = abc.ABCMeta
 
   def set_driver(self, measurement_driver):
     self.driver = measurement_driver

--- a/opentuner/measurement/interface.py
+++ b/opentuner/measurement/interface.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import abc
 import argparse
 import errno
@@ -10,6 +12,7 @@ import subprocess
 import threading
 import time
 from multiprocessing.pool import ThreadPool
+from future.utils import with_metaclass
 
 try:
   import resource
@@ -35,11 +38,10 @@ argparser.add_argument('--parallel-compile', action='store_true',
 the_io_thread_pool = None
 
 
-class MeasurementInterface(object):
+class MeasurementInterface(with_metaclass(abc.ABCMeta, object)):
   """
   abstract base class for compile and measurement
   """
-  __metaclass__ = abc.ABCMeta
 
   def __init__(self,
                args=None,
@@ -238,7 +240,7 @@ class MeasurementInterface(object):
     the_io_thread_pool_init(self.args.parallelism)
     if limit is float('inf'):
       limit = None
-    if type(cmd) in (str, unicode):
+    if type(cmd) in (str, str):
       kwargs['shell'] = True
     killed = False
     t0 = time.time()
@@ -327,7 +329,7 @@ def the_io_thread_pool_init(parallelism=1):
   if the_io_thread_pool is None:
     the_io_thread_pool = ThreadPool(2 * parallelism)
     # make sure the threads are started up
-    the_io_thread_pool.map(int, range(2 * parallelism))
+    the_io_thread_pool.map(int, list(range(2 * parallelism)))
 
 
 def goodkillpg(pid):
@@ -352,7 +354,7 @@ def goodwait(p):
     try:
       rv = p.wait()
       return rv
-    except OSError, e:
+    except OSError as e:
       if e.errno != errno.EINTR:
         raise
 

--- a/opentuner/resultsdb/__init__.py
+++ b/opentuner/resultsdb/__init__.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 
-from connect import connect
+from .connect import connect
 
-import models
+from . import models
 
 

--- a/opentuner/resultsdb/connect.py
+++ b/opentuner/resultsdb/connect.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
-from models import Base, _Meta
+from .models import Base, _Meta
 import logging
 import time
 from pprint import pprint

--- a/opentuner/resultsdb/models.py
+++ b/opentuner/resultsdb/models.py
@@ -1,3 +1,6 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy import create_engine
@@ -8,7 +11,7 @@ from sqlalchemy import (
 import sqlalchemy
 import re
 
-from cPickle import dumps, loads
+from pickle import dumps, loads
 from gzip import zlib
 class CompressedPickler(object):
   @classmethod

--- a/opentuner/search/__init__.py
+++ b/opentuner/search/__init__.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 
-import driver
-import objective
-import plugin
-import technique
+from . import driver
+from . import objective
+from . import plugin
+from . import technique
 

--- a/opentuner/search/bandittechniques.py
+++ b/opentuner/search/bandittechniques.py
@@ -1,3 +1,9 @@
+from __future__ import division
+from __future__ import absolute_import
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import abc
 import copy
 import logging
@@ -37,8 +43,7 @@ class BanditQueue(object):
     value represent how unsure we are (optimal bandit solution)
     """
     if self.use_counts[key] > 0:
-      return math.sqrt((2.0 * math.log(len(self.history), 2.0))
-                       / self.use_counts[key])
+      return math.sqrt(old_div((2.0 * math.log(len(self.history), 2.0)), self.use_counts[key]))
     else:
       return float('inf')
 
@@ -183,7 +188,7 @@ class AUCBanditMetaTechnique(MetaSearchTechnique):
     for i in range(num_techniques):
       for j in range(retry_count):
         # pick a technique or generate a composable
-        if random.random() < float(len(basetechniques)) / (len(basetechniques) + generator_weight*len(generators)):
+        if random.random() < old_div(float(len(basetechniques)), (len(basetechniques) + generator_weight*len(generators))):
           candidate = copy.deepcopy(random.choice(basetechniques))
         else:
           # pick a random generator
@@ -204,7 +209,7 @@ class AUCBanditMutationTechnique(SearchTechnique):
     self.pending_results = []
 
   def handle_requested_result(self, result):
-    for i in xrange(len(self.pending_results)):
+    for i in range(len(self.pending_results)):
       cfg, name, index = self.pending_results[i]
       if result.configuration == cfg:
         self.bandit.on_result((name, index), result.was_new_best)
@@ -242,7 +247,7 @@ class AUCBanditMutationTechnique(SearchTechnique):
   def init_bandit(self, cfg):
     options = []
     for param in self.manipulator.parameters(cfg):
-      for i in xrange(len(param.manipulators(cfg))):
+      for i in range(len(param.manipulators(cfg))):
         options.append((param.name, i))
     # TODO(jansel): remove assumption that set of parameters are fixed
     self.bandit = AUCBanditQueue(options, **self.bandit_kwargs)
@@ -256,13 +261,13 @@ class AUCBanditMutationTechnique(SearchTechnique):
       return self.manipulator.random()
 
 
-import evolutionarytechniques
-import differentialevolution
-import simplextechniques
-import patternsearch
-import simulatedannealing
-from pso import PSO, HybridParticle
-import globalGA
+from . import evolutionarytechniques
+from . import differentialevolution
+from . import simplextechniques
+from . import patternsearch
+from . import simulatedannealing
+from .pso import PSO, HybridParticle
+from . import globalGA
 register(AUCBanditMutationTechnique())
 
 register(AUCBanditMetaTechnique([

--- a/opentuner/search/composableevolutionarytechniques.py
+++ b/opentuner/search/composableevolutionarytechniques.py
@@ -1,14 +1,21 @@
+from __future__ import absolute_import
+from past.builtins import cmp
+from builtins import map
+from builtins import range
+from builtins import object
 import random
 import time
 import sys
 import json
 from fn import _
-from technique import all_techniques
-from technique import register
-from technique import register_generator
-from technique import SequentialSearchTechnique
-from manipulator import *
+from .technique import all_techniques
+from .technique import register
+from .technique import register_generator
+from .technique import SequentialSearchTechnique
+from .manipulator import *
 from opentuner.search.manipulator import Parameter
+from future.utils import with_metaclass
+from functools import reduce
 
 
 class PopulationMember(object):
@@ -27,11 +34,10 @@ class PopulationMember(object):
     self.timestamp = time.time()
 
 
-class ComposableEvolutionaryTechnique(SequentialSearchTechnique):
+class ComposableEvolutionaryTechnique(with_metaclass(abc.ABCMeta, SequentialSearchTechnique)):
   """
   An abstract base class for a technique that is composable with operators
   """
-  __metaclass__ = abc.ABCMeta
 
   # operator_map - from param-type to dict with operator name + list of arguments TODO
   # min_parent - minimum number of parents returned. Limits which operators can be used
@@ -354,7 +360,7 @@ class ComposableEvolutionaryTechnique(SequentialSearchTechnique):
     """
     generate a composable technique with random operators
     """
-    from manipulator import composable_operators
+    from .manipulator import composable_operators
     # randomly select a composable technique to generate
     t = cls(*args, **kwargs)
     if manipulator is None:
@@ -402,7 +408,7 @@ class RandomThreeParentsComposableTechnique(ComposableEvolutionaryTechnique):
     # copy oldest
     cfg = self.manipulator.copy(population[0].config)
 
-    shuffled_population = map(_.config, population[1:])
+    shuffled_population = list(map(_.config, population[1:]))
     # mix in the global best configuration
     shuffled_population += ([self.get_global_best_configuration()]
                             * self.information_sharing)

--- a/opentuner/search/differentialevolution.py
+++ b/opentuner/search/differentialevolution.py
@@ -1,9 +1,15 @@
+from __future__ import division
+from __future__ import absolute_import
+from builtins import map
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import random
 import time
 import logging
 from fn import _
-from technique import register
-from technique import SearchTechnique
+from .technique import register
+from .technique import SearchTechnique
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.WARNING)
@@ -50,12 +56,11 @@ class DifferentialEvolution(SearchTechnique):
     self.population = [PopulationMember(
         self.driver.get_configuration(
             self.manipulator.random()), submitted=False)
-        for z in xrange(self.population_size)]
+        for z in range(self.population_size)]
 
   def oldest_pop_member(self):
     # since tests are run in parallel, exclude things with a replacement pending
-    pop_without_replacements = filter(lambda x: x.candidate_replacement is None,
-                                      self.population)
+    pop_without_replacements = [x for x in self.population if x.candidate_replacement is None]
     if not pop_without_replacements:
       # everything has a pending replacement
       return None
@@ -84,7 +89,7 @@ class DifferentialEvolution(SearchTechnique):
       return None
 
     config = None
-    for retry in xrange(self.duplicate_retries):
+    for retry in range(self.duplicate_retries):
       config = self.driver.get_configuration(
           self.create_new_configuration(oldest_pop_member))
       if not self.driver.has_results(config):
@@ -110,9 +115,9 @@ class DifferentialEvolution(SearchTechnique):
                        * self.information_sharing)
 
     random.shuffle(shuffled_pop)
-    x1, x2, x3 = map(_.config.data, shuffled_pop[0:3])
+    x1, x2, x3 = list(map(_.config.data, shuffled_pop[0:3]))
 
-    use_f = random.random() / 2.0 + 0.5
+    use_f = old_div(random.random(), 2.0) + 0.5
 
     params = self.manipulator.param_names(cfg, x1, x2, x3)
     random.shuffle(params)

--- a/opentuner/search/driver.py
+++ b/opentuner/search/driver.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from builtins import range
+from builtins import object
 import argparse
 import copy
 import logging
@@ -62,7 +65,7 @@ class SearchDriver(DriverBase):
     if self.args.list_techniques:
       techniques, generators = technique.all_techniques()
       for t in techniques:
-        print t.name
+        print(t.name)
       sys.exit(0)
 
     if self.args.generate_bandit_technique:
@@ -157,7 +160,7 @@ class SearchDriver(DriverBase):
   def run_generation_techniques(self):
     tests_this_generation = 0
     self.plugin_proxy.before_techniques()
-    for z in xrange(self.args.parallelism):
+    for z in range(self.args.parallelism):
       if self.seed_cfgs:
         config = self.get_configuration(self.seed_cfgs.pop())
         dr = DesiredResult(configuration=config,
@@ -241,7 +244,7 @@ class SearchDriver(DriverBase):
           rv = []
           for plugin in plugins:
             rv.append(getattr(plugin, method_name)(*args, **kwargs))
-          return filter(lambda x: x is not None, rv)
+          return [x for x in rv if x is not None]
 
         return plugin_method_proxy
 
@@ -261,7 +264,7 @@ class SearchDriver(DriverBase):
     no_tests_generations = 0
 
     # prime pipeline with tests
-    for z in xrange(self.args.pipelining):
+    for z in range(self.args.pipelining):
       self.run_generation_techniques()
       self.generation += 1
 

--- a/opentuner/search/evolutionarytechniques.py
+++ b/opentuner/search/evolutionarytechniques.py
@@ -1,7 +1,13 @@
+from __future__ import division
+from __future__ import absolute_import
+from builtins import map
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import abc
 import copy
 import random
-from technique import SearchTechnique
+from .technique import SearchTechnique
 from opentuner.search import technique
 
 class EvolutionaryTechnique(SearchTechnique):
@@ -28,15 +34,15 @@ class EvolutionaryTechnique(SearchTechnique):
     #TODO: set limit value
 
     parents = self.selection()
-    parents = map(copy.deepcopy, parents)
-    parent_hashes = map(self.manipulator.hash_config, parents)
+    parents = list(map(copy.deepcopy, parents))
+    parent_hashes = list(map(self.manipulator.hash_config, parents))
 
     if len(parents) > 1:
       cfg = self.crossover(parents)
     else:
       cfg = parents[0]
 
-    for z in xrange(10): #retries
+    for z in range(10): #retries
       self.mutation(cfg)
       if self.manipulator.hash_config(cfg) in parent_hashes:
         continue # try again
@@ -124,7 +130,7 @@ class CrossoverMixin(object):
     params = self.manipulator.parameters(cfg1)
     for param in params:
       if param.is_permutation() and param.size>6:
-        getattr(param, self.crossover_op)(new, cfg1, cfg2, d=param.size/3)
+        getattr(param, self.crossover_op)(new, cfg1, cfg2, d=old_div(param.size,3))
     return new
 
 

--- a/opentuner/search/globalGA.py
+++ b/opentuner/search/globalGA.py
@@ -1,7 +1,11 @@
+from __future__ import absolute_import
+from builtins import map
+from builtins import range
+from builtins import object
 import abc
 import copy
 import random
-from technique import SearchTechnique
+from .technique import SearchTechnique
 from opentuner.search import technique
 
 class GlobalEvolutionaryTechnique(SearchTechnique):
@@ -29,15 +33,15 @@ class GlobalEvolutionaryTechnique(SearchTechnique):
     #TODO: set limit value
 
     parents = self.selection()
-    parents = map(copy.deepcopy, parents)
-    parent_hashes = map(self.manipulator.hash_config, parents)
+    parents = list(map(copy.deepcopy, parents))
+    parent_hashes = list(map(self.manipulator.hash_config, parents))
 
     if len(parents) > 1:
       cfg = self.crossover(parents)
     else:
       cfg = parents[0]
 
-    for z in xrange(10): #retries
+    for z in range(10): #retries
       self.mutation(cfg)
       if self.manipulator.hash_config(cfg) in parent_hashes:
         continue # try again

--- a/opentuner/search/metatechniques.py
+++ b/opentuner/search/metatechniques.py
@@ -1,9 +1,13 @@
+from past.builtins import cmp
+from builtins import zip
+from builtins import str
 import abc
 import logging
 from collections import deque, defaultdict
 from fn import _
 
 from .technique import SearchTechniqueBase
+import sys
 
 log = logging.getLogger(__name__)
 
@@ -24,7 +28,7 @@ class MetaSearchTechnique(SearchTechniqueBase):
     for t in self.techniques:
       while t.name in names:
         t.name += '~'
-      t.name = intern(t.name)
+      t.name = sys.intern(t.name)
       names.add(t.name)
 
   def set_driver(self, driver):
@@ -68,7 +72,7 @@ class MetaSearchTechnique(SearchTechniqueBase):
   def debug_log(self):
     if self.log_freq and sum(self.logging_use_counters.values())>self.log_freq:
       log.info("%s: %s", self.name,
-          str(sorted(self.logging_use_counters.items(), key = _[1]*-1)))
+          str(sorted(list(self.logging_use_counters.items()), key = _[1]*-1)))
       self.logging_use_counters = defaultdict(int)
 
 class RoundRobinMetaSearchTechnique(MetaSearchTechnique):

--- a/opentuner/search/objective.py
+++ b/opentuner/search/objective.py
@@ -1,3 +1,8 @@
+from __future__ import division
+from past.builtins import cmp
+from builtins import map
+from past.utils import old_div
+from builtins import object
 import abc
 import logging
 
@@ -5,15 +10,15 @@ from fn import _
 
 import opentuner
 from opentuner.resultsdb.models import *
+from future.utils import with_metaclass
 
 log = logging.getLogger(__name__)
 
 
-class SearchObjective(object):
+class SearchObjective(with_metaclass(abc.ABCMeta, object)):
   """
   delegates the comparison of results and configurations
   """
-  __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
   def result_order_by_terms(self):
@@ -103,7 +108,7 @@ class SearchObjective(object):
     if results.count() == 0:
       return None
     else:
-      return max(map(_.time, self.driver.results_query(config=config)))
+      return max(list(map(_.time, self.driver.results_query(config=config))))
 
 
   def project_compare(self, a1, a2, b1, b2, factor=1.0):
@@ -167,14 +172,14 @@ class MinimizeTime(SearchObjective):
 
   def config_compare(self, config1, config2):
     """cmp() compatible comparison of resultsdb.models.Configuration"""
-    return cmp(min(map(_.time, self.driver.results_query(config=config1))),
-               min(map(_.time, self.driver.results_query(config=config2))))
+    return cmp(min(list(map(_.time, self.driver.results_query(config=config1)))),
+               min(list(map(_.time, self.driver.results_query(config=config2)))))
 
   def result_relative(self, result1, result2):
     """return None, or a relative goodness of resultsdb.models.Result"""
     if result2.time == 0:
       return float('inf') * result1.time
-    return result1.time / result2.time
+    return old_div(result1.time, result2.time)
 
 
 class MaximizeAccuracy(SearchObjective):
@@ -196,7 +201,7 @@ class MaximizeAccuracy(SearchObjective):
     # note opposite order
     if result1.accuracy == 0:
       return float('inf') * result2.accuracy
-    return result2.accuracy / result1.accuracy
+    return old_div(result2.accuracy, result1.accuracy)
 
   def stats_quality_score(self, result, worst_result, best_result):
     """return a score for statistics"""
@@ -275,11 +280,11 @@ class ThresholdAccuracyMinimizeTime(SearchObjective):
     results = self.driver.results_query(config=config)
     if results.count() == 0:
       return None
-    if self.accuracy_target > min(map(_.accuracy, results)):
+    if self.accuracy_target > min(list(map(_.accuracy, results))):
       m = self.low_accuracy_limit_multiplier
     else:
       m = 1.0
-    return m * max(map(_.time, results))
+    return m * max(list(map(_.time, results)))
 
 
   def filter_acceptable(self, query):

--- a/opentuner/search/plugin.py
+++ b/opentuner/search/plugin.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from builtins import map
+from builtins import object
 import abc
 import argparse
 import logging
@@ -5,6 +8,7 @@ import time
 
 from datetime import datetime
 from fn import _
+from future.utils import with_metaclass
 
 log = logging.getLogger(__name__)
 display_log = logging.getLogger(__name__ + ".DisplayPlugin")
@@ -57,8 +61,7 @@ class SearchPlugin(object):
     """
     pass
 
-class DisplayPlugin(SearchPlugin):
-  __metaclass__ = abc.ABCMeta
+class DisplayPlugin(with_metaclass(abc.ABCMeta, SearchPlugin)):
   def __init__(self, display_period=5):
     super(DisplayPlugin, self).__init__()
     self.last  = time.time()
@@ -117,14 +120,12 @@ class FileDisplayPlugin(SearchPlugin):
   def on_result(self, result):
     if self.out and result.time < self.last_best:
       self.last_best = result.time
-      print >>self.out, \
-          (result.collection_date - self.start_date).total_seconds(), \
-          result.time
+      print((result.collection_date - self.start_date).total_seconds(), \
+          result.time, file=self.out)
       self.out.flush()
     if self.details:
-      print >>self.details, \
-          (result.collection_date - self.start_date).total_seconds(), \
-          result.time
+      print((result.collection_date - self.start_date).total_seconds(), \
+          result.time, file=self.details)
       self.details.flush()
 
 def get_enabled(args):

--- a/opentuner/search/pso.py
+++ b/opentuner/search/pso.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=2 shiftwidth=2 softtabstop=2 expandtab autoindent smarttab
-from manipulator import *
+from __future__ import absolute_import
+from builtins import range
+from builtins import object
+from .manipulator import *
 from opentuner.search import technique
 import random
 import math

--- a/opentuner/search/simulatedannealing.py
+++ b/opentuner/search/simulatedannealing.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 from opentuner.search import technique
 import math
 import random
@@ -19,7 +22,7 @@ class PseudoAnnealingSearch(technique.SequentialSearchTechnique):
     #create temperature schedule (list of temps)
     cool_schedule = [temps[0]]
     for i in range(len(temps)-1):
-      step = (float(temps[i+1]) - temps[i])/ext_intervals[i]
+      step = old_div((float(temps[i+1]) - temps[i]),ext_intervals[i])
       for j in range(ext_intervals[i]):
         cool_schedule.append(max(cool_schedule[-1] + step,0))
       
@@ -49,7 +52,7 @@ class PseudoAnnealingSearch(technique.SequentialSearchTechnique):
       #Determine temperature
       temp = self.cool_schedule[min(counter,max_time)]
       #scale stepsize with temp and time (arbitrary)
-      step_size = math.exp(-(20 + counter/100)/(temp+ 1)) 
+      step_size = math.exp(old_div(-(20 + old_div(counter,100)),(temp+ 1))) 
           
       #get candidate neighbors using manipulator
       points = list()

--- a/opentuner/search/technique.py
+++ b/opentuner/search/technique.py
@@ -1,3 +1,9 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import next
+from builtins import map
+from builtins import str
+from builtins import object
 import abc
 import argparse
 import logging
@@ -10,7 +16,8 @@ from datetime import datetime
 from fn import _
 
 from opentuner.resultsdb.models import *
-from plugin import SearchPlugin
+from .plugin import SearchPlugin
+from future.utils import with_metaclass
 
 log = logging.getLogger(__name__)
 #log.setLevel(logging.DEBUG)
@@ -23,11 +30,10 @@ argparser.add_argument('--list-techniques','-lt', action='store_true',
 argparser.add_argument('--generate-bandit-technique','-gbt', action='store_true',
                        help="randomly generate a bandit to use")
 
-class SearchTechniqueBase(object):
+class SearchTechniqueBase(with_metaclass(abc.ABCMeta, object)):
   """
   abstract base class for search techniques, with minimal interface
   """
-  __metaclass__ = abc.ABCMeta
 
   def __init__(self, name = None):
     super(SearchTechniqueBase, self).__init__()
@@ -192,7 +198,7 @@ class AsyncProceduralSearchTechnique(SearchTechnique):
       self.gen = self.call_main_generator()
     if not self.done:
       try:
-        return self.gen.next()
+        return next(self.gen)
       except StopIteration:
         log.debug("%s: generator finished", self.name)
         self.done = True
@@ -246,7 +252,7 @@ class SequentialSearchTechnique(AsyncProceduralSearchTechnique):
           self.rounds_since_novel_request = 0
         yield None # give other techniques a shot
       try:
-        p = subgen.next()
+        p = next(subgen)
         if p:
           self.pending_tests.append(p)
       except StopIteration:
@@ -267,8 +273,7 @@ class SequentialSearchTechnique(AsyncProceduralSearchTechnique):
           log.error("%s: still waiting for %d pending tests (c=%d)",
                      self.name, len(self.pending_tests), c)
 
-        self.pending_tests = filter(lambda x: not self.driver.has_results(x),
-                                    self.pending_tests)
+        self.pending_tests = [x for x in self.pending_tests if not self.driver.has_results(x)]
         if self.pending_tests:
           self.rounds_since_novel_request = 0
           yield False # wait
@@ -336,7 +341,7 @@ def get_enabled(args):
   techniques, generators = all_techniques()
   if args.list_techniques:
     for t in techniques:
-      print t.name
+      print(t.name)
     sys.exit(0)
 
   if not args.technique:
@@ -350,7 +355,7 @@ def get_enabled(args):
   return [t for t in techniques if t.name in args.technique]
 
 def get_root(args):
-  from metatechniques import RoundRobinMetaSearchTechnique
+  from .metatechniques import RoundRobinMetaSearchTechnique
   enabled = get_enabled(args)
   if len(enabled) == 1:
     return enabled[0]

--- a/opentuner/tuningrunmain.py
+++ b/opentuner/tuningrunmain.py
@@ -1,4 +1,6 @@
+from __future__ import print_function
 # vim: tabstop=2 shiftwidth=2 softtabstop=2 expandtab autoindent smarttab
+from builtins import object
 import argparse
 import copy
 import inspect
@@ -92,7 +94,7 @@ class TuningRunMain(object):
 
     manipulator = measurement_interface.manipulator()
     if args.print_search_space_size:
-      print "10^{%.2f}" % math.log(manipulator.search_space_size(), 10)
+      print("10^{%.2f}" % math.log(manipulator.search_space_size(), 10))
       sys.exit(0)
     # show internal parameter representation
     if args.print_params:
@@ -107,8 +109,8 @@ class TuningRunMain(object):
         else:
           params_dict[cls] = [p]
       for k in params_dict:
-        print k, params_dict[k]
-        print
+        print(k, params_dict[k])
+        print()
       sys.exit(0)
 
     input_manager = measurement_interface.input_manager()

--- a/opentuner/utils/adddeps.py
+++ b/opentuner/utils/adddeps.py
@@ -1,4 +1,5 @@
 
+from past.builtins import execfile
 import sys
 from os.path import normpath, realpath, dirname, join, isfile
 

--- a/opentuner/utils/compactdb.py
+++ b/opentuner/utils/compactdb.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 if __name__ == '__main__':
-  import adddeps
+  from . import adddeps
 
 import argparse
 import logging

--- a/opentuner/utils/dictconfig.py
+++ b/opentuner/utils/dictconfig.py
@@ -18,6 +18,8 @@
 # IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from builtins import str
+from builtins import object
 import logging.handlers
 import re
 import sys
@@ -237,14 +239,14 @@ class BaseConfigurator(object):
     def configure_custom(self, config):
         """Configure an object with a user-supplied factory."""
         c = config.pop('()')
-        if not hasattr(c, '__call__') and hasattr(types, 'ClassType') and type(c) != types.ClassType:
+        if not hasattr(c, '__call__') and hasattr(types, 'ClassType') and type(c) != type:
             c = self.resolve(c)
         props = config.pop('.', None)
         # Check for valid identifiers
         kwargs = dict([(k, config[k]) for k in config if valid_ident(k)])
         result = c(**kwargs)
         if props:
-            for name, value in props.items():
+            for name, value in list(props.items()):
                 setattr(result, name, value)
         return result
 
@@ -288,21 +290,21 @@ class DictConfigurator(BaseConfigurator):
                                 level = handler_config.get('level', None)
                                 if level:
                                     handler.setLevel(_checkLevel(level))
-                            except StandardError as e:
+                            except Exception as e:
                                 raise ValueError('Unable to configure handler '
                                                  '%r: %s' % (name, e))
                 loggers = config.get('loggers', EMPTY_DICT)
                 for name in loggers:
                     try:
                         self.configure_logger(name, loggers[name], True)
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure logger '
                                          '%r: %s' % (name, e))
                 root = config.get('root', None)
                 if root:
                     try:
                         self.configure_root(root, True)
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure root '
                                          'logger: %s' % e)
             else:
@@ -317,7 +319,7 @@ class DictConfigurator(BaseConfigurator):
                     try:
                         formatters[name] = self.configure_formatter(
                                                             formatters[name])
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure '
                                          'formatter %r: %s' % (name, e))
                 # Next, do filters - they don't refer to anything else, either
@@ -325,7 +327,7 @@ class DictConfigurator(BaseConfigurator):
                 for name in filters:
                     try:
                         filters[name] = self.configure_filter(filters[name])
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure '
                                          'filter %r: %s' % (name, e))
 
@@ -338,7 +340,7 @@ class DictConfigurator(BaseConfigurator):
                         handler = self.configure_handler(handlers[name])
                         handler.name = name
                         handlers[name] = handler
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure handler '
                                          '%r: %s' % (name, e))
                 # Next, do loggers - they refer to handlers and filters
@@ -377,7 +379,7 @@ class DictConfigurator(BaseConfigurator):
                         existing.remove(name)
                     try:
                         self.configure_logger(name, loggers[name])
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure logger '
                                          '%r: %s' % (name, e))
 
@@ -400,7 +402,7 @@ class DictConfigurator(BaseConfigurator):
                 if root:
                     try:
                         self.configure_root(root)
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure root '
                                          'logger: %s' % e)
         finally:
@@ -442,7 +444,7 @@ class DictConfigurator(BaseConfigurator):
         for f in filters:
             try:
                 filterer.addFilter(self.config['filters'][f])
-            except StandardError as e:
+            except Exception as e:
                 raise ValueError('Unable to add filter %r: %s' % (f, e))
 
     def configure_handler(self, config):
@@ -451,14 +453,14 @@ class DictConfigurator(BaseConfigurator):
         if formatter:
             try:
                 formatter = self.config['formatters'][formatter]
-            except StandardError as e:
+            except Exception as e:
                 raise ValueError('Unable to set formatter '
                                  '%r: %s' % (formatter, e))
         level = config.pop('level', None)
         filters = config.pop('filters', None)
         if '()' in config:
             c = config.pop('()')
-            if not hasattr(c, '__call__') and hasattr(types, 'ClassType') and type(c) != types.ClassType:
+            if not hasattr(c, '__call__') and hasattr(types, 'ClassType') and type(c) != type:
                 c = self.resolve(c)
             factory = c
         else:
@@ -468,7 +470,7 @@ class DictConfigurator(BaseConfigurator):
                 'target' in config:
                 try:
                     config['target'] = self.config['handlers'][config['target']]
-                except StandardError as e:
+                except Exception as e:
                     raise ValueError('Unable to set target handler '
                                      '%r: %s' % (config['target'], e))
             elif issubclass(klass, logging.handlers.SMTPHandler) and\
@@ -503,7 +505,7 @@ class DictConfigurator(BaseConfigurator):
         for h in handlers:
             try:
                 logger.addHandler(self.config['handlers'][h])
-            except StandardError as e:
+            except Exception as e:
                 raise ValueError('Unable to add handler %r: %s' % (h, e))
 
     def common_logger_config(self, logger, config, incremental=False):

--- a/opentuner/utils/stats.py
+++ b/opentuner/utils/stats.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python
 
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import str
+from builtins import zip
+from builtins import map
+from builtins import range
+from builtins import object
+from past.utils import old_div
+from functools import reduce
 if __name__ == '__main__':
-  import adddeps
+  from . import adddeps
 
 import argparse
 import csv
@@ -40,7 +50,7 @@ argparser.add_argument('--stats-input', default="opentuner.db")
 argparser.add_argument('--min-runs',  type=int, default=1,
                        help="ignore series with less then N runs")
 
-PCTSTEPS = map(_/20.0, xrange(21))
+PCTSTEPS = list(map(old_div(_,20.0), list(range(21))))
 
 def mean(vals):
   n = 0.0
@@ -51,13 +61,13 @@ def mean(vals):
       d += 1.0
   if d == 0.0:
     return None
-  return n/d
+  return old_div(n,d)
 
 def median(vals):
   vals = sorted(vals)
-  a = (len(vals)-1)/2
-  b = (len(vals))/2
-  return (vals[a]+vals[b])/2.0
+  a = old_div((len(vals)-1),2)
+  b = old_div((len(vals)),2)
+  return old_div((vals[a]+vals[b]),2.0)
 
 def percentile(vals, pct):
   vals = sorted(vals)
@@ -67,13 +77,13 @@ def percentile(vals, pct):
   return (1.0-(pos-a))*vals[a] + (pos-a)*vals[b]
 
 def variance(vals):
-  vals = filter(lambda x: x is not None, vals)
+  vals = [x for x in vals if x is not None]
   avg = mean(vals)
   if avg is None:
     return None
   if avg in (float('inf'), float('-inf')):
     return avg
-  return mean(map((_ - avg) ** 2, vals))
+  return mean(list(map((_ - avg) ** 2, vals)))
 
 def stddev(vals):
   var = variance(vals)
@@ -128,7 +138,7 @@ class StatsMain(object):
 
       if self.args.label:
         q = q.filter(TuningRun.name.in_(
-          map(str.strip,self.args.label.split(','))))
+          list(map(str.strip,self.args.label.split(',')))))
 
       for tr in q:
         d = run_dir(self.args.stats_dir, tr)
@@ -136,12 +146,12 @@ class StatsMain(object):
         dir_label_runs[d][run_label(tr)].append((tr, session))
 
     summary_report = defaultdict(lambda: defaultdict(list))
-    for d, label_runs in dir_label_runs.iteritems():
+    for d, label_runs in list(dir_label_runs.items()):
       if not os.path.isdir(d):
         os.makedirs(d)
-      session = label_runs.values()[0][0][1]
-      objective = label_runs.values()[0][0][0].objective
-      all_run_ids = map(_[0].id, itertools.chain(*label_runs.values()))
+      session = list(label_runs.values())[0][0][1]
+      objective = list(label_runs.values())[0][0][0].objective
+      all_run_ids = list(map(_[0].id, itertools.chain(*list(label_runs.values()))))
       q = (session.query(Result)
            .filter(Result.tuning_run_id.in_(all_run_ids))
            .filter(Result.time < float('inf'))
@@ -155,7 +165,7 @@ class StatsMain(object):
       best = q.limit(1).one()
       worst = q.offset(acceptable-1).limit(1).one()
 
-      map(len, label_runs.values())
+      list(map(len, list(label_runs.values())))
 
       log.info("%s -- best %.4f / worst %.f4 "
                "-- %d of %d acceptable -- %d techniques with %d to %d runs",
@@ -164,13 +174,13 @@ class StatsMain(object):
                worst.time,
                acceptable,
                total,
-               len(label_runs.values()),
-               min(map(len, label_runs.values())),
-               max(map(len, label_runs.values())))
+               len(list(label_runs.values())),
+               min(list(map(len, list(label_runs.values())))),
+               max(list(map(len, list(label_runs.values())))))
 
       for label, runs in sorted(label_runs.items()):
         if len(runs) < self.args.min_runs:
-          print len(runs) ,self.args.min_runs
+          print(len(runs) ,self.args.min_runs)
           continue
         log.debug('%s/%s has %d runs %s',d, label, len(runs), runs[0][0].args.technique)
         self.combined_stats_over_time(d, label, runs, objective, worst, best)
@@ -191,9 +201,9 @@ class StatsMain(object):
           norm = objective.stats_quality_score(best, worst, best)
           if norm > 0.00001:
             summary_report[d][run_label(run, short=True)] = (
-                percentile(final_scores, 0.5) / norm,
-                percentile(final_scores, 0.1) / norm,
-                percentile(final_scores, 0.9) / norm,
+                old_div(percentile(final_scores, 0.5), norm),
+                old_div(percentile(final_scores, 0.1), norm),
+                old_div(percentile(final_scores, 0.9), norm),
               )
           else:
             summary_report[d][run_label(run, short=True)] = (
@@ -206,20 +216,20 @@ class StatsMain(object):
     with open(self.args.stats_dir+ "/summary.dat", 'w') as o:
       # make summary report
       keys = sorted(reduce(set.union,
-                           [set(x.keys()) for x in summary_report.values()],
+                           [set(x.keys()) for x in list(summary_report.values())],
                            set()))
-      print >>o, '#####',
+      print('#####', end=' ', file=o)
       for k in keys:
-        print >>o, k,
-      print >>o
+        print(k, end=' ', file=o)
+      print(file=o)
       for d, label_vals in sorted(summary_report.items()):
-        print >>o, d.split('/')[-2],
+        print(d.split('/')[-2], end=' ', file=o)
         for k in keys:
           if k in label_vals:
-            print >>o, '-', label_vals[k][0], label_vals[k][1], label_vals[k][2],
+            print('-', label_vals[k][0], label_vals[k][1], label_vals[k][2], end=' ', file=o)
           else:
-            print >>o, '-', '-', '-', '-',
-        print >>o
+            print('-', '-', '-', '-', end=' ', file=o)
+        print(file=o)
 
     if keys:
       plotcmd = ["""1 w lines lt 1 lc rgb "black" notitle""",
@@ -234,8 +244,8 @@ class StatsMain(object):
 
 
 
-    for d, label_runs in dir_label_runs.iteritems():
-      labels = [k for k,v in label_runs.iteritems()
+    for d, label_runs in list(dir_label_runs.items()):
+      labels = [k for k,v in list(label_runs.items())
                 if len(v)>=self.args.min_runs]
       self.gnuplot_file(d,
                         "medianperfe",
@@ -259,8 +269,8 @@ class StatsMain(object):
     # print
     # print "Mean Scores", d
     # pprint(self.technique_scores(d, labels, 'mean'))
-      print
-      print "Median Scores", d
+      print()
+      print("Median Scores", d)
       pprint(self.technique_scores(d, labels, '0.5'))
 
 
@@ -317,11 +327,11 @@ class StatsMain(object):
     log.debug("writing stats for %s to %s", label, output_dir)
     by_run = [self.stats_over_time(session, run, extract_fn, combine_fn, no_data)
               for run, session in runs]
-    max_len = max(map(len, by_run))
+    max_len = max(list(map(len, by_run)))
 
     by_run_streams = [Stream() << x << repeat(x[-1], max_len-len(x))
                       for x in by_run]
-    by_quanta = zip(*by_run_streams[:])
+    by_quanta = list(zip(*by_run_streams[:]))
 
     def data_file(suffix, headers, value_function):
       with open(os.path.join(output_dir, label+suffix), 'w') as fd:
@@ -380,11 +390,11 @@ class StatsMain(object):
 
   def gnuplot_file(self, output_dir, prefix, plotcmd):
     with open(os.path.join(output_dir, prefix+'.gnuplot'), 'w') as fd:
-      print >>fd, 'set terminal postscript eps enhanced color'
-      print >>fd, 'set output "%s"' % (prefix+'.eps')
-      print >>fd, 'set ylabel "Execution Time (seconds)"'
-      print >>fd, 'set xlabel "Autotuning Time (seconds)"'
-      print >>fd, 'plot', ',\\\n'.join(plotcmd)
+      print('set terminal postscript eps enhanced color', file=fd)
+      print('set output "%s"' % (prefix+'.eps'), file=fd)
+      print('set ylabel "Execution Time (seconds)"', file=fd)
+      print('set xlabel "Autotuning Time (seconds)"', file=fd)
+      print('plot', ',\\\n'.join(plotcmd), file=fd)
 
     try:
       subprocess.call(['gnuplot', prefix+'.gnuplot'], cwd=output_dir, stdin=None)
@@ -393,9 +403,9 @@ class StatsMain(object):
 
   def gnuplot_summary_file(self, output_dir, prefix, plotcmd):
     with open(os.path.join(output_dir, prefix+'.gnuplot'), 'w') as fd:
-      print >>fd, 'set terminal postscript eps enhanced color'
-      print >>fd, 'set output "%s"' % (prefix+'.eps')
-      print >>fd, '''
+      print('set terminal postscript eps enhanced color', file=fd)
+      print('set output "%s"' % (prefix+'.eps'), file=fd)
+      print('''
 set boxwidth 0.9
 set style fill solid 1.00 border 0
 set style histogram errorbars gap 2 lw 1
@@ -409,8 +419,8 @@ set key out vert top left
 set size 1.5,1
 set ytics 1
 
-'''
-      print >>fd, 'plot', ',\\\n'.join(plotcmd)
+''', file=fd)
+      print('plot', ',\\\n'.join(plotcmd), file=fd)
     subprocess.call(['gnuplot', prefix+'.gnuplot'], cwd=output_dir, stdin=None)
 
 
@@ -446,7 +456,7 @@ set ytics 1
       if self.args.by_request_count:
         quanta = dr.id - first_id
       else:
-        quanta = int(duration / self.args.stats_quanta)
+        quanta = int(old_div(duration, self.args.stats_quanta))
       while len(value_by_quanta) <= quanta:
         value_by_quanta.append(value_by_quanta[-1])
 

--- a/opentuner/utils/stats_matplotlib.py
+++ b/opentuner/utils/stats_matplotlib.py
@@ -1,7 +1,15 @@
 #!usr/bin/python
 
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import str
+from builtins import zip
+from builtins import map
+from builtins import range
+from past.utils import old_div
 if __name__ == '__main__':
-  import adddeps
+  from . import adddeps
 
 import itertools
 import math
@@ -17,7 +25,7 @@ from fn import Stream
 from fn.iters import repeat
 from opentuner import resultsdb
 
-PCTSTEPS = map(_/20.0, xrange(21))
+PCTSTEPS = list(map(old_div(_,20.0), list(range(21))))
 
 
 def mean(vals):
@@ -65,8 +73,8 @@ def get_dbs(path, db_type='sqlite:///'):
       e, sm = resultsdb.connect(db_type + db_path)
       dbs.append(sm())
     except Exception as e:
-      print e
-      print "Error encountered while connecting to db"
+      print(e)
+      print("Error encountered while connecting to db")
   return dbs
 
 
@@ -95,9 +103,9 @@ def matplotlibplot_file(labels, xlim = None, ylim = None, disp_types=['median'])
         cols = [1]
         data = mean_values
       elif disp_type == 'all_percentiles':
-        cols = range(1,22)
+        cols = list(range(1,22))
 
-      plotted_data = [[] for x in xrange(len(cols))]
+      plotted_data = [[] for x in range(len(cols))]
 
       x_indices = []
       for data_point in data[1:]:
@@ -145,11 +153,11 @@ def combined_stats_over_time(label,
 
   by_run = [stats_over_time(session, run, extract_fn, combine_fn, no_data)
             for run, session in runs]
-  max_len = max(map(len, by_run))
+  max_len = max(list(map(len, by_run)))
 
   by_run_streams = [Stream() << x << repeat(x[-1], max_len-len(x))
                     for x in by_run]
-  by_quanta = zip(*by_run_streams[:])
+  by_quanta = list(zip(*by_run_streams[:]))
 
   # TODO: Fix this, this variable should be configurable
   stats_quanta = 10
@@ -204,7 +212,7 @@ def stats_over_time(session,
     if by_request_count:
       quanta = dr.id - first_id
     else:
-      quanta = int(duration / stats_quanta)
+      quanta = int(old_div(duration, stats_quanta))
     while len(value_by_quanta) <= quanta:
       value_by_quanta.append(value_by_quanta[-1])
 
@@ -252,10 +260,10 @@ def get_values(labels):
       dir_label_runs[run_label(tr)][run_label(tr)].append((tr, db))
   all_run_ids = list()
   returned_values = {}
-  for d, label_runs in dir_label_runs.iteritems():
-    all_run_ids = map(_[0].id, itertools.chain(*label_runs.values()))
-    session = label_runs.values()[0][0][1]
-    objective = label_runs.values()[0][0][0].objective
+  for d, label_runs in list(dir_label_runs.items()):
+    all_run_ids = list(map(_[0].id, itertools.chain(*list(label_runs.values()))))
+    session = list(label_runs.values())[0][0][1]
+    objective = list(label_runs.values())[0][0][0].objective
 
     q = (session.query(resultsdb.models.Result)
          .filter(resultsdb.models.Result.tuning_run_id.in_(all_run_ids))
@@ -287,4 +295,4 @@ def get_values(labels):
 if __name__ == '__main__':
     labels = [u'timeouts', u'always_reorder', u'add_store_at', u'all_options']
     get_values(labels)
-    print get_all_labels()
+    print(get_all_labels())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 argparse>=1.2.1
 fn>=0.2.12
+future
 numpy>=1.8.0
 pysqlite>=2.6.3
 SQLAlchemy>=0.8.2

--- a/stats_app/stats_app/urls.py
+++ b/stats_app/stats_app/urls.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 from django.conf.urls import patterns, include, url
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
-import views.charts
+from . import views.charts
 admin.autodiscover()
 
 urlpatterns = patterns('',

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -1,3 +1,5 @@
+from builtins import next
+from builtins import range
 import unittest
 import opentuner
 import mock
@@ -8,7 +10,7 @@ from opentuner.search import manipulator
 def faked_random(nums):
     f = fake_random(nums)
     def inner(*args, **kwargs):
-        return f.next()
+        return next(f)
     return inner
 
 def fake_random(nums):

--- a/tests/test_technique.py
+++ b/tests/test_technique.py
@@ -1,3 +1,4 @@
+from builtins import next
 import unittest
 import opentuner
 import mock
@@ -7,7 +8,7 @@ from opentuner.search import manipulator
 def faked_random(nums):
   f = fake_random(nums)
   def inner(*args, **kwargs):
-    return f.next()
+    return next(f)
   return inner
 
 def fake_random(nums):


### PR DESCRIPTION
See #103. This commit uses an automatic run of [python-future](http://python-future.org/#) to add python 3 compatibility, and using the future package in python2, this code should support both python2 and python3. I tested in Python 3.6 and Python 2.7 on Mac OS X through the current Anaconda python channels. 

I did a few manual changes in manipulator.py to allow hashing of the configurations by enabling encoding. 

In my brief testing it works fine with both (although the opentuner.db folder created in py36 contains pickle dumps of a newer version, so running the py27 version in that folder afterwards crashes)