### PR TITLE
Python 3 support (without using future)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import absolute_import
 import sys
 import os
 

--- a/examples/gccflags/adddeps.py
+++ b/examples/gccflags/adddeps.py
@@ -1,6 +1,7 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))
 

--- a/examples/gccflags/gccflags.py
+++ b/examples/gccflags/gccflags.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import absolute_import
 import adddeps  # fix sys.path
 
 import math
@@ -17,6 +19,9 @@ import sys
 
 from opentuner.resultsdb.models import Result, TuningRun
 from opentuner.search import manipulator
+from six.moves import filter
+from six.moves import map
+from six.moves import range
 
 FLAGS_WORKING_CACHE_FILE = 'cc_flags.json'
 PARAMS_DEFAULTS_CACHE_FILE = 'cc_param_defaults.json'
@@ -114,7 +119,7 @@ class GccFlagsTuner(opentuner.measurement.MeasurementInterface):
                                   re.MULTILINE)
       log.info('Determining which of %s possible gcc flags work',
                len(found_cc_flags))
-      found_cc_flags = filter(self.check_if_flag_works, found_cc_flags)
+      found_cc_flags = list(filter(self.check_if_flag_works, found_cc_flags))
       json.dump(found_cc_flags, open(FLAGS_WORKING_CACHE_FILE, 'w'))
     return found_cc_flags
 
@@ -294,13 +299,13 @@ class GccFlagsTuner(opentuner.measurement.MeasurementInterface):
     if self.args.debug:
       while len(flags) > 8:
         log.error("compile error with %d flags, diagnosing...", len(flags))
-        tmpflags = filter(lambda x: random.choice((True, False)), flags)
+        tmpflags = [x for x in flags if random.choice((True, False))]
         if fails(tmpflags):
           flags = tmpflags
 
       # linear scan
       minimal_flags = []
-      for i in xrange(len(flags)):
+      for i in range(len(flags)):
         tmpflags = minimal_flags + flags[i + 1:]
         if not fails(tmpflags):
           minimal_flags.append(flags[i])
@@ -339,7 +344,7 @@ class GccFlagsTuner(opentuner.measurement.MeasurementInterface):
 
   def save_final_config(self, configuration):
     """called at the end of tuning"""
-    print "Best flags written to gccflags_final_config.{json,cmd}"
+    print("Best flags written to gccflags_final_config.{json,cmd}")
     self.manipulator().save_to_file(configuration.data,
                                     'gccflags_final_config.json')
     with open('gccflags_final_config.cmd', 'w') as fd:
@@ -350,10 +355,10 @@ class GccFlagsTuner(opentuner.measurement.MeasurementInterface):
     q = session.query(TuningRun).filter_by(state='COMPLETE')
     total = q.count()
     for tr in q:
-      print tr.program.name
+      print(tr.program.name)
       for flag in self.cfg_to_flags(tr.final_config.data):
         counter[flag] += 1.0 / total
-    print counter.most_common(20)
+    print(counter.most_common(20))
 
   def flag_importance(self):
     """
@@ -372,20 +377,20 @@ class GccFlagsTuner(opentuner.measurement.MeasurementInterface):
       if math.isinf(impact):
         impact = 0.0
       counter[flag] = impact
-      print flag, '{:.4f}'.format(impact)
+      print(flag, '{:.4f}'.format(impact))
     total_impact = sum(counter.values())
     remaining_impact = total_impact
-    print r'\bf Flag & \bf Importance \\\hline'
+    print(r'\bf Flag & \bf Importance \\\hline')
     for flag, impact in counter.most_common(20):
-      print r'{} & {:.1f}\% \\\hline'.format(flag, 100.0 * impact / total_impact)
+      print(r'{} & {:.1f}\% \\\hline'.format(flag, 100.0 * impact / total_impact))
       remaining_impact -= impact
-    print r'{} other flags & {:.1f}% \\\hline'.format(
-      len(flags) - 20, 100.0 * remaining_impact / total_impact)
+    print(r'{} other flags & {:.1f}% \\\hline'.format(
+      len(flags) - 20, 100.0 * remaining_impact / total_impact))
 
   def flags_mean_time(self, flags, trials=10):
     precompiled = self.compile_with_flags(flags, 0)
     total = 0.0
-    for _ in xrange(trials):
+    for _ in range(trials):
       total += self.run_precompiled(None, None, None, precompiled, 0).time
     return total / trials
 

--- a/examples/gccflags/gccflags_minimal.py
+++ b/examples/gccflags/gccflags_minimal.py
@@ -4,6 +4,7 @@
 #
 # This is an extremely simplified version meant only for tutorials
 #
+from __future__ import absolute_import
 import adddeps  # fix sys.path
 
 import opentuner

--- a/examples/halide/adddeps.py
+++ b/examples/halide/adddeps.py
@@ -1,6 +1,7 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))
 

--- a/examples/halide/halidetuner.py
+++ b/examples/halide/halidetuner.py
@@ -14,6 +14,8 @@
 # Halide can be found here: https://github.com/halide/Halide
 #
 
+from __future__ import print_function
+from __future__ import absolute_import
 import adddeps  # fix sys.path
 
 import argparse
@@ -37,6 +39,9 @@ from opentuner.search.manipulator import PowerOfTwoParameter
 from opentuner.search.manipulator import PermutationParameter
 from opentuner.search.manipulator import BooleanParameter
 from opentuner.search.manipulator import ScheduleParameter
+from functools import reduce
+from six.moves import range
+from six.moves import input
 
 
 COMPILE_CMD = (
@@ -146,7 +151,7 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
     schedule_deps = dict()
     for var in func['vars']:
       schedule_vars.append((var, 0))
-      for i in xrange(1, self.args.nesting):
+      for i in range(1, self.args.nesting):
         schedule_vars.append((var, i))
         schedule_deps[(var, i - 1)] = [(var, i)]
     return ScheduleParameter('{0}_compute_order'.format(name), schedule_vars,
@@ -175,7 +180,7 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
           '{0}_unroll'.format(name), 1, self.args.max_split_factor))
         manipulator.add_parameter(BooleanParameter(
           '{0}_parallel'.format(name)))
-        for nesting in xrange(1, self.args.nesting):
+        for nesting in range(1, self.args.nesting):
           manipulator.add_parameter(PowerOfTwoParameter(
             '{0}_splitfactor_{1}_{2}'.format(name, nesting, var),
             1, self.args.max_split_factor))
@@ -201,7 +206,7 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
       compute_order = cfg['{0}_compute_order'.format(name)]
       for var in func['vars']:
         var_names[(name, var, 0)] = var
-        for nesting in xrange(1, self.args.nesting):
+        for nesting in range(1, self.args.nesting):
           split_factor = cfg.get('{0}_splitfactor_{1}_{2}'.format(
             name, nesting, var), 0)
           if split_factor > 1 and (name, var, nesting - 1) in var_names:
@@ -222,17 +227,17 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
       else:
         unroll = 1
 
-      print >> o, 'Halide::Func(funcs["%s"])' % name
+      print('Halide::Func(funcs["%s"])' % name, file=o)
 
       for var in func['vars']:
         # handle all splits
-        for nesting in xrange(1, self.args.nesting):
+        for nesting in range(1, self.args.nesting):
           split_factor = cfg.get('{0}_splitfactor_{1}_{2}'.format(
             name, nesting, var), 0)
           if split_factor <= 1:
             break
 
-          for nesting2 in xrange(nesting + 1, self.args.nesting):
+          for nesting2 in range(nesting + 1, self.args.nesting):
             split_factor2 = cfg.get('{0}_splitfactor_{1}_{2}'.format(
               name, nesting2, var), 0)
             if split_factor2 <= 1:
@@ -246,30 +251,30 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
             split_factor *= unroll
             split_factor *= vectorize
 
-          print >> o, '.split({0}, {0}, {1}, {2})'.format(
-            last_var_name, var_name, split_factor)
+          print('.split({0}, {0}, {1}, {2})'.format(
+            last_var_name, var_name, split_factor), file=o)
 
       # drop unused variables and truncate (Halide supports only 10 reorders)
       if len(var_name_order[name]) > 1:
-        print >> o, '.reorder({0})'.format(
-            ', '.join(reversed(var_name_order[name][:10])))
+        print('.reorder({0})'.format(
+            ', '.join(reversed(var_name_order[name][:10]))), file=o)
 
       # reorder_storage
       store_order_enabled = cfg['{0}_store_order_enabled'.format(name)]
       if store_order_enabled or not self.args.gated_store_reorder:
         store_order = cfg['{0}_store_order'.format(name)]
         if len(store_order) > 1:
-          print >> o, '.reorder_storage({0})'.format(', '.join(store_order))
+          print('.reorder_storage({0})'.format(', '.join(store_order)), file=o)
 
       if unroll > 1:
         # apply unrolling to innermost var
-        print >> o, '.unroll({0}, {1})'.format(
-          var_name_order[name][-1], unroll * vectorize)
+        print('.unroll({0}, {1})'.format(
+          var_name_order[name][-1], unroll * vectorize), file=o)
 
       if vectorize > 1:
         # apply vectorization to innermost var
-        print >> o, '.vectorize({0}, {1})'.format(
-          var_name_order[name][-1], vectorize)
+        print('.vectorize({0}, {1})'.format(
+          var_name_order[name][-1], vectorize), file=o)
       
       # compute_at(not root)
       if (compute_at[name] is not None and
@@ -277,15 +282,15 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
         at_func, at_idx = compute_at[name]
         try:
           at_var = var_name_order[at_func][-at_idx]
-          print >> o, '.compute_at(Halide::Func(funcs["{0}"]), {1})'.format(at_func, at_var)
+          print('.compute_at(Halide::Func(funcs["{0}"]), {1})'.format(at_func, at_var), file=o)
           if not self.args.enable_store_at:
             pass  # disabled
           elif store_at[name] is None:
-            print >> o, '.store_root()'
+            print('.store_root()', file=o)
           elif store_at[name] != compute_at[name]:
             at_func, at_idx = store_at[name]
             at_var = var_name_order[at_func][-at_idx]
-            print >> o, '.store_at(Halide::Func(funcs["{0}"]), {1})'.format(at_func, at_var)
+            print('.store_at(Halide::Func(funcs["{0}"]), {1})'.format(at_func, at_var), file=o)
         except IndexError:
           # this is expected when at_idx is too large
           # TODO: implement a cleaner fix
@@ -295,10 +300,10 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
         parallel = cfg['{0}_parallel'.format(name)]
         if parallel:
           # only apply parallelism to outermost var of root funcs
-          print >> o, '.parallel({0})'.format(var_name_order[name][0])
-        print >> o, '.compute_root()'
+          print('.parallel({0})'.format(var_name_order[name][0]), file=o)
+        print('.compute_root()', file=o)
 
-      print >> o, ';'
+      print(';', file=o)
 
     if temp_vars:
       return 'Halide::Var {0};\n{1}'.format(
@@ -430,16 +435,16 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
 
   def save_final_config(self, configuration):
     """called at the end of tuning"""
-    print 'Final Configuration:'
-    print self.cfg_to_schedule(configuration.data)
+    print('Final Configuration:')
+    print(self.cfg_to_schedule(configuration.data))
 
   def debug_log_schedule(self, filename, source):
     open(filename, 'w').write(source)
-    print 'offending schedule written to {0}'.format(filename)
+    print('offending schedule written to {0}'.format(filename))
 
   def debug_schedule(self, filename, source):
     self.debug_log_schedule(filename, source)
-    raw_input('press ENTER to continue')
+    input('press ENTER to continue')
 
   def make_settings_file(self):
     dump_call_graph_dir = os.path.join(os.path.dirname(__file__),
@@ -468,7 +473,7 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
     settings = {'input_size': '1024, 1024', 'functions': callgraph}
     json.dump(settings, open(self.args.settings_file, 'w'), sort_keys=True,
               indent=2)
-    print textwrap.dedent('''
+    print(textwrap.dedent('''
 
       {0} has been generated based on call graph of program.
 
@@ -478,7 +483,7 @@ class HalideTuner(opentuner.measurement.MeasurementInterface):
       be applied manually.  Some temporary variables not in the source code
       need to be manually removed.
 
-    '''.format(self.args.settings_file))
+    '''.format(self.args.settings_file)))
 
 
 class ComputeAtStoreAtParser(object):
@@ -587,7 +592,7 @@ class HalideComputeAtScheduleParameter(ScheduleParameter):
     for func in functions:
       last = None
       for idx in reversed(['c'] + # 'c' = compute location (and close loops)
-          range(1, len(func['vars']) * args.nesting + 1) +
+          list(range(1, len(func['vars']) * args.nesting + 1)) +
           ['s']):  # 's' = storage location
         name = (func['name'], idx)
         if last is not None:
@@ -646,12 +651,12 @@ def random_test(args):
   m = HalideTuner(args)
   cfg = m.manipulator().random()
   pprint(cfg)
-  print
+  print()
   schedule = m.cfg_to_schedule(cfg)
-  print schedule
-  print
-  print 'Schedule', m.run_schedule(schedule, 30)
-  print 'Baseline', m.run_baseline()
+  print(schedule)
+  print()
+  print('Schedule', m.run_schedule(schedule, 30))
+  print('Baseline', m.run_baseline())
 
 
 def random_source(args):
@@ -663,7 +668,7 @@ def random_source(args):
   cfg = m.manipulator().random()
   schedule = m.cfg_to_schedule(cfg)
   source = m.schedule_to_source(schedule)
-  print source
+  print(source)
 
 
 def main(args):

--- a/examples/hpl/adddeps.py
+++ b/examples/hpl/adddeps.py
@@ -1,6 +1,7 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))
 

--- a/examples/hpl/hpl.py
+++ b/examples/hpl/hpl.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import adddeps #fix sys.path
 
 import argparse
@@ -91,7 +93,7 @@ class HPLinpack(MeasurementInterface):
       '''
       called at the end of autotuning with the best resultsdb.models.Configuration
       '''
-      print "Final configuration", configuration.data
+      print("Final configuration", configuration.data)
             
 if __name__ == '__main__':
   args = parser.parse_args()

--- a/examples/mario/adddeps.py
+++ b/examples/mario/adddeps.py
@@ -1,6 +1,7 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))
 

--- a/examples/petabricks/adddeps.py
+++ b/examples/petabricks/adddeps.py
@@ -1,6 +1,7 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))
 

--- a/examples/petabricks/deps.py
+++ b/examples/petabricks/deps.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import sys
 

--- a/examples/petabricks/import_old_result.py
+++ b/examples/petabricks/import_old_result.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+from __future__ import absolute_import
 import adddeps  # fix sys.path
 
 import argparse
@@ -106,7 +108,7 @@ def main(args):
         state='COMPLETE')
       session.add(desired_result)
       tuningrun.end_date = date
-      print gen, date, result.time
+      print(gen, date, result.time)
 
   session.commit()
 

--- a/examples/petabricks/pbtuner.py
+++ b/examples/petabricks/pbtuner.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+from __future__ import absolute_import
 import adddeps  # fix sys.path
 
 import re
@@ -19,6 +21,8 @@ from opentuner.search.manipulator import (ConfigurationManipulator,
                                           SelectorParameter,
                                           SwitchParameter,
                                           PermutationParameter, )
+import six
+from six.moves import range
 
 try:
   from lxml import etree
@@ -63,7 +67,7 @@ class PetaBricksInterface(MeasurementInterface):
     r = dict()
 
     # direct copy
-    for k, v in cfg.iteritems():
+    for k, v in six.iteritems(cfg):
       if k[0] != '.':
         r[k] = v
 
@@ -82,7 +86,7 @@ class PetaBricksInterface(MeasurementInterface):
     limit = min(limit, self.args.upper_limit)
     with tempfile.NamedTemporaryFile(suffix='.petabricks.cfg') as cfgtmp:
       for k, v in self.build_config(desired_result.configuration.data).items():
-        print >> cfgtmp, k, '=', v
+        print(k, '=', v, file=cfgtmp)
       cfgtmp.flush()
       if args.program_input:
         input_opts = ['--iogen-run=' + args.program_input,
@@ -124,7 +128,7 @@ class PetaBricksInterface(MeasurementInterface):
     with open(args.program_cfg_output, 'w') as fd:
       cfg = self.build_config(configuration.data)
       for k, v in sorted(cfg.items()):
-        print >> fd, k, '=', v
+        print(k, '=', v, file=fd)
     log.info("final configuration written to %s", args.program_cfg_output)
 
   def manipulator(self):
@@ -162,7 +166,7 @@ class PetaBricksInterface(MeasurementInterface):
 
     for name, choices in self.choice_sites.items():
       manipulator.add_parameter(
-        SelectorParameter('.' + name, range(choices + 1),
+        SelectorParameter('.' + name, list(range(choices + 1)),
                           upper_limit / choices))
 
     self.manipulator = manipulator

--- a/examples/py_api/adddeps.py
+++ b/examples/py_api/adddeps.py
@@ -1,6 +1,7 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))
 

--- a/examples/py_api/api_example.py
+++ b/examples/py_api/api_example.py
@@ -5,7 +5,9 @@ Examples usage of a Python API interface to opentuner.
 Unlike the other examples, this code lets the user control the main() of
 the program and calls into opentuner to get new configurations to test.
 """
+from __future__ import print_function
 
+from __future__ import absolute_import
 import adddeps  # add opentuner to path in dev mode
 
 import opentuner
@@ -16,6 +18,7 @@ from opentuner.search.manipulator import ConfigurationManipulator
 from opentuner.search.manipulator import IntegerParameter
 import logging
 import argparse
+from six.moves import range
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +41,7 @@ def main():
                                             program_name='api_test',
                                             program_version='0.1')
     api = TuningRunManager(interface, args)
-    for x in xrange(500):
+    for x in range(500):
         desired_result = api.get_next_desired_result()
         if desired_result is None:
           # The search space for this example is very small, so sometimes
@@ -51,7 +54,7 @@ def main():
 
     best_cfg = api.get_best_configuration()
     api.finish()
-    print 'best x found was', best_cfg['x']
+    print('best x found was', best_cfg['x'])
 
 if __name__ == '__main__':
   main()

--- a/examples/py_api/multiple_tuning_runs.py
+++ b/examples/py_api/multiple_tuning_runs.py
@@ -7,7 +7,9 @@ the program and calls into opentuner to get new configurations to test.
 
 This version runs multiple tuning runs at once in a single process.
 """
+from __future__ import print_function
 
+from __future__ import absolute_import
 import adddeps  # add opentuner to path in dev mode
 
 import opentuner
@@ -18,6 +20,8 @@ from opentuner.search.manipulator import ConfigurationManipulator
 from opentuner.search.manipulator import IntegerParameter
 import logging
 import argparse
+from six.moves import range
+from six.moves import zip
 
 log = logging.getLogger(__name__)
 
@@ -63,7 +67,7 @@ def main():
             create_test_tuning_run('sqlite:////tmp/b.db'),
             create_test_tuning_run('sqlite:////tmp/c.db')]
     test_funcs = [test_func1, test_func2, test_func3]
-    for x in xrange(100):
+    for x in range(100):
       for api, test_func in zip(apis, test_funcs):
         desired_result = api.get_next_desired_result()
         if desired_result is None:

--- a/examples/rosenbrock/adddeps.py
+++ b/examples/rosenbrock/adddeps.py
@@ -1,6 +1,7 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))
 

--- a/examples/rosenbrock/rosenbrock.py
+++ b/examples/rosenbrock/rosenbrock.py
@@ -8,6 +8,8 @@
 # http://en.wikipedia.org/wiki/Test_functions_for_optimization
 #
 
+from __future__ import print_function
+from __future__ import absolute_import
 import adddeps  # fix sys.path
 
 import argparse
@@ -17,6 +19,7 @@ import opentuner
 from opentuner.measurement import MeasurementInterface
 from opentuner.search.manipulator import ConfigurationManipulator
 from opentuner.search.manipulator import FloatParameter
+from six.moves import range
 
 log = logging.getLogger(__name__)
 
@@ -36,12 +39,12 @@ class Rosenbrock(MeasurementInterface):
     val = 0.0
     if self.args.function == 'rosenbrock':
       # the actual rosenbrock function:
-      for d in xrange(self.args.dimensions - 1):
+      for d in range(self.args.dimensions - 1):
         x0 = cfg[d]
         x1 = cfg[d + 1]
         val += 100.0 * (x1 - x0 ** 2) ** 2 + (x0 - 1) ** 2
     elif self.args.function == 'sphere':
-      for d in xrange(self.args.dimensions):
+      for d in range(self.args.dimensions):
         xi = cfg[d]
         val += xi ** 2
     elif self.args.function == 'beale':
@@ -56,7 +59,7 @@ class Rosenbrock(MeasurementInterface):
 
   def manipulator(self):
     manipulator = ConfigurationManipulator()
-    for d in xrange(self.args.dimensions):
+    for d in range(self.args.dimensions):
       manipulator.add_parameter(FloatParameter(d,
                                                -self.args.domain,
                                                self.args.domain))
@@ -72,7 +75,7 @@ class Rosenbrock(MeasurementInterface):
     """
     called at the end of autotuning with the best resultsdb.models.Configuration
     """
-    print "Final configuration", configuration.data
+    print("Final configuration", configuration.data)
 
 
 if __name__ == '__main__':

--- a/examples/tsp/adddeps.py
+++ b/examples/tsp/adddeps.py
@@ -1,6 +1,7 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))
 

--- a/examples/tsp/tsp.py
+++ b/examples/tsp/tsp.py
@@ -5,6 +5,7 @@
 # http://en.wikipedia.org/wiki/Travelling_salesman_problem
 #
 
+from __future__ import absolute_import
 import adddeps #fix sys.path
 
 import argparse
@@ -17,6 +18,7 @@ from opentuner.search.objective import MinimizeTime
 from opentuner.measurement import MeasurementInterface
 from opentuner.measurement.inputmanager import FixedInputManager
 from opentuner.tuningrunmain import TuningRunMain
+from six.moves import range
 
 
 parser = argparse.ArgumentParser(parents=opentuner.argparsers())
@@ -44,7 +46,7 @@ class TSP(MeasurementInterface):
 
     def manipulator(self):
         manipulator = ConfigurationManipulator()
-        manipulator.add_parameter(PermutationParameter(0, range(len(self.distance))))
+        manipulator.add_parameter(PermutationParameter(0, list(range(len(self.distance)))))
         return manipulator
 
     def solution(self):

--- a/examples/tutorials/adddeps.py
+++ b/examples/tutorials/adddeps.py
@@ -1,5 +1,6 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))

--- a/examples/tutorials/mmm_tuner.py
+++ b/examples/tutorials/mmm_tuner.py
@@ -4,6 +4,8 @@
 #
 # This is an extremely simplified version meant only for tutorials
 #
+from __future__ import print_function
+from __future__ import absolute_import
 import adddeps  # fix sys.path
 
 import opentuner
@@ -48,7 +50,7 @@ class GccFlagsTuner(MeasurementInterface):
 
   def save_final_config(self, configuration):
     """called at the end of tuning"""
-    print "Optimal block size written to mmm_final_config.json:", configuration.data
+    print("Optimal block size written to mmm_final_config.json:", configuration.data)
     self.manipulator().save_to_file(configuration.data,
                                     'mmm_final_config.json')
 

--- a/examples/unitary/adddeps.py
+++ b/examples/unitary/adddeps.py
@@ -1,6 +1,7 @@
 # we would prefer a symbolic link, but it does not work on windows
+from __future__ import absolute_import
 import os
 target = os.path.join(os.path.dirname(__file__),
                       '../../opentuner/utils/adddeps.py')
-execfile(target, dict(__file__=target))
+exec(compile(open(target).read(), target, 'exec'), dict(__file__=target))
 

--- a/examples/unitary/cla_func.py
+++ b/examples/unitary/cla_func.py
@@ -1,5 +1,8 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import numpy as np
 import math
+from six.moves import range
 
 
 class Op:
@@ -80,8 +83,8 @@ class Op:
     # in case one isn't unitary the program stops
     for k in range(len(self.M)):
       if (np.trace(self.M[k] * self.M[k].getH()) - 2 != 0):
-        print "Operator " + self.name[k] + " (no. " + str(
-          k) + ") isn't unitary!"
+        print("Operator " + self.name[k] + " (no. " + str(
+          k) + ") isn't unitary!")
         exit()
 
   def determine_index_of_mutation_partners(self):
@@ -106,8 +109,8 @@ class Op:
           found_operator = True
 
       if found_operator == False:
-        print "Couldn't find the anti-operator for operator " + self.name[
-          k] + " (no " + str(k) + ")"
+        print("Couldn't find the anti-operator for operator " + self.name[
+          k] + " (no " + str(k) + ")")
 
   def __str__(self):
     # just a test to play around

--- a/examples/unitary/input_generator.py
+++ b/examples/unitary/input_generator.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
 import numpy as np
 import math
 import random
+from six.moves import range
 
 
 def generate_random_Ugoal_HARD(N, **kwargs):

--- a/examples/unitary/unitary.py
+++ b/examples/unitary/unitary.py
@@ -10,6 +10,8 @@
 # Contributed by Clarice D. Aiello <clarice@mit.edu>
 #
 
+from __future__ import print_function
+from __future__ import absolute_import
 import adddeps  # fix sys.path
 
 import argparse
@@ -17,11 +19,12 @@ import logging
 import math
 import random
 import sys
+from six.moves import range
 
 try:
   import numpy as np
 except:
-  print >> sys.stderr, '''
+  print('''
 
 ERROR: import numpy failed, please install numpy
 
@@ -30,7 +33,7 @@ Possible things to try:
   ../../venv/bin/easy_install numpy
   sudo apt-get install python-numpy
 
-'''
+''', file=sys.stderr)
   raise
 
 import opentuner
@@ -68,7 +71,7 @@ generators = {
 parser = argparse.ArgumentParser(parents=opentuner.argparsers())
 parser.add_argument('--seq-len', type=int, default=10,
                     help='maximum length for generated sequence')
-parser.add_argument('--goal-type', choices=generators.keys(), default='hard',
+parser.add_argument('--goal-type', choices=list(generators.keys()), default='hard',
                     help='method used to generate goal')
 parser.add_argument('--goal-n', type=int, default=100,
                     help='argument to ugoal generator')
@@ -90,7 +93,7 @@ class Unitary(opentuner.measurement.MeasurementInterface):
   def run(self, desired_result, input, limit):
     cfg = desired_result.configuration.data
 
-    sequence = [cfg[i] for i in xrange(self.args.seq_len)
+    sequence = [cfg[i] for i in range(self.args.seq_len)
                 if cfg[i] < self.num_operators]
     # sequence can be shorter than self.args.seq_len with null operator
 
@@ -106,7 +109,7 @@ class Unitary(opentuner.measurement.MeasurementInterface):
 
   def manipulator(self):
     manipulator = ConfigurationManipulator()
-    for d in xrange(self.args.seq_len):
+    for d in range(self.args.seq_len):
       # we add 1 to num_operators allow a ignored 'null' operator
       manipulator.add_parameter(SwitchParameter(d, self.num_operators + 1))
     return manipulator
@@ -116,9 +119,9 @@ class Unitary(opentuner.measurement.MeasurementInterface):
     called at the end of autotuning with the best resultsdb.models.Configuration
     '''
     cfg = configuration.data
-    sequence = [cfg[i] for i in xrange(self.args.seq_len)
+    sequence = [cfg[i] for i in range(self.args.seq_len)
                 if cfg[i] < self.num_operators]
-    print "Final sequence", sequence
+    print("Final sequence", sequence)
 
   def objective(self):
     # we could have also chosen to store 1.0 - accuracy in the time field

--- a/misc/livedisplay.py
+++ b/misc/livedisplay.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import argparse
 import subprocess
@@ -33,18 +35,18 @@ while '\n' not in open(args.details).read():
 
 p1 = subprocess.Popen(["gnuplot"], stdin=subprocess.PIPE)
 p1.stdin.write(open(args.gnuplot_filename).read())
-print >> p1.stdin, 'set title "Zoomed out"'
-print >> p1.stdin, "set xrange [0:%f]" % args.xrange
-print >> p1.stdin, "set yrange [0:%f]" % args.yrange2
+print('set title "Zoomed out"', file=p1.stdin)
+print("set xrange [0:%f]" % args.xrange, file=p1.stdin)
+print("set yrange [0:%f]" % args.yrange2, file=p1.stdin)
 p1.stdin.flush()
 
 time.sleep(1)
 
 p2 = subprocess.Popen(["gnuplot"], stdin=subprocess.PIPE)
 p2.stdin.write(open(args.gnuplot_filename).read())
-print >> p2.stdin, 'set title "Zoomed in"'
-print >> p2.stdin, "set xrange [0:%f]" % args.xrange
-print >> p2.stdin, "set yrange [0:%f]" % args.yrange
+print('set title "Zoomed in"', file=p2.stdin)
+print("set xrange [0:%f]" % args.xrange, file=p2.stdin)
+print("set yrange [0:%f]" % args.yrange, file=p2.stdin)
 p2.stdin.flush()
 
 procs = [p1, p2]
@@ -52,6 +54,6 @@ procs = [p1, p2]
 while True:
   time.sleep(1)
   for p in procs:
-    print >> p.stdin, "replot"
+    print("replot", file=p.stdin)
     p.stdin.flush()
 

--- a/opentuner/__init__.py
+++ b/opentuner/__init__.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 
-import measurement
-import resultsdb
-import search
-import tuningrunmain
+from . import measurement
+from . import resultsdb
+from . import search
+from . import tuningrunmain
 from opentuner.measurement import MeasurementInterface
 from opentuner.resultsdb.models import Configuration
 from opentuner.resultsdb.models import DesiredResult

--- a/opentuner/api.py
+++ b/opentuner/api.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from datetime import datetime
 from opentuner import tuningrunmain
 

--- a/opentuner/driverbase.py
+++ b/opentuner/driverbase.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from opentuner.resultsdb.models import *
 
 

--- a/opentuner/measurement/__init__.py
+++ b/opentuner/measurement/__init__.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 
-import driver
-import interface
-from interface import MeasurementInterface
-from driver import MeasurementDriver
+from . import driver
+from . import interface
+from .interface import MeasurementInterface
+from .driver import MeasurementDriver
 

--- a/opentuner/measurement/driver.py
+++ b/opentuner/measurement/driver.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import argparse
 import logging
 import time
@@ -11,6 +13,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from opentuner.driverbase import DriverBase
 from opentuner.resultsdb.models import *
+from six.moves import zip
 
 log = logging.getLogger(__name__)
 
@@ -202,8 +205,8 @@ class MeasurementDriver(DriverBase):
         self.run_desired_result(dr, compile_result, dr.id)
         try:
           self.interface.cleanup(dr.id)
-        except RuntimeError, e:
-          print e
+        except RuntimeError as e:
+          print(e)
           # print 'Done!'
       thread_pool.close()
     else:

--- a/opentuner/measurement/inputmanager.py
+++ b/opentuner/measurement/inputmanager.py
@@ -1,13 +1,14 @@
+from __future__ import absolute_import
 import abc
 import opentuner
 from opentuner.resultsdb.models import *
+import six
 
 
-class InputManager(object):
+class InputManager(six.with_metaclass(abc.ABCMeta, object)):
   """
   abstract base class for compile and measurement
   """
-  __metaclass__ = abc.ABCMeta
 
   def set_driver(self, measurement_driver):
     self.driver = measurement_driver

--- a/opentuner/measurement/interface.py
+++ b/opentuner/measurement/interface.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import abc
 import argparse
 import errno
@@ -10,6 +11,8 @@ import subprocess
 import threading
 import time
 from multiprocessing.pool import ThreadPool
+import six
+from six.moves import range
 
 try:
   import resource
@@ -35,11 +38,10 @@ argparser.add_argument('--parallel-compile', action='store_true',
 the_io_thread_pool = None
 
 
-class MeasurementInterface(object):
+class MeasurementInterface(six.with_metaclass(abc.ABCMeta, object)):
   """
   abstract base class for compile and measurement
   """
-  __metaclass__ = abc.ABCMeta
 
   def __init__(self,
                args=None,
@@ -238,7 +240,7 @@ class MeasurementInterface(object):
     the_io_thread_pool_init(self.args.parallelism)
     if limit is float('inf'):
       limit = None
-    if type(cmd) in (str, unicode):
+    if type(cmd) in (str, six.text_type):
       kwargs['shell'] = True
     killed = False
     t0 = time.time()
@@ -327,7 +329,7 @@ def the_io_thread_pool_init(parallelism=1):
   if the_io_thread_pool is None:
     the_io_thread_pool = ThreadPool(2 * parallelism)
     # make sure the threads are started up
-    the_io_thread_pool.map(int, range(2 * parallelism))
+    the_io_thread_pool.map(int, list(range(2 * parallelism)))
 
 
 def goodkillpg(pid):
@@ -352,7 +354,7 @@ def goodwait(p):
     try:
       rv = p.wait()
       return rv
-    except OSError, e:
+    except OSError as e:
       if e.errno != errno.EINTR:
         raise
 

--- a/opentuner/resultsdb/__init__.py
+++ b/opentuner/resultsdb/__init__.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 
-from connect import connect
+from .connect import connect
 
-import models
+from . import models
 
 

--- a/opentuner/resultsdb/connect.py
+++ b/opentuner/resultsdb/connect.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
-from models import Base, _Meta
+from .models import Base, _Meta
 import logging
 import time
 from pprint import pprint

--- a/opentuner/resultsdb/models.py
+++ b/opentuner/resultsdb/models.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy import create_engine
@@ -8,7 +9,7 @@ from sqlalchemy import (
 import sqlalchemy
 import re
 
-from cPickle import dumps, loads
+from six.moves.cPickle import dumps, loads
 from gzip import zlib
 class CompressedPickler(object):
   @classmethod

--- a/opentuner/search/__init__.py
+++ b/opentuner/search/__init__.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 
-import driver
-import objective
-import plugin
-import technique
+from . import driver
+from . import objective
+from . import plugin
+from . import technique
 

--- a/opentuner/search/bandittechniques.py
+++ b/opentuner/search/bandittechniques.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import abc
 import copy
 import logging
@@ -7,6 +8,7 @@ from collections import deque
 
 from .metatechniques import MetaSearchTechnique
 from .technique import register, SearchTechnique, all_techniques, get_random_generator_technique
+from six.moves import range
 
 log = logging.getLogger(__name__)
 
@@ -204,7 +206,7 @@ class AUCBanditMutationTechnique(SearchTechnique):
     self.pending_results = []
 
   def handle_requested_result(self, result):
-    for i in xrange(len(self.pending_results)):
+    for i in range(len(self.pending_results)):
       cfg, name, index = self.pending_results[i]
       if result.configuration == cfg:
         self.bandit.on_result((name, index), result.was_new_best)
@@ -242,7 +244,7 @@ class AUCBanditMutationTechnique(SearchTechnique):
   def init_bandit(self, cfg):
     options = []
     for param in self.manipulator.parameters(cfg):
-      for i in xrange(len(param.manipulators(cfg))):
+      for i in range(len(param.manipulators(cfg))):
         options.append((param.name, i))
     # TODO(jansel): remove assumption that set of parameters are fixed
     self.bandit = AUCBanditQueue(options, **self.bandit_kwargs)
@@ -256,13 +258,13 @@ class AUCBanditMutationTechnique(SearchTechnique):
       return self.manipulator.random()
 
 
-import evolutionarytechniques
-import differentialevolution
-import simplextechniques
-import patternsearch
-import simulatedannealing
-from pso import PSO, HybridParticle
-import globalGA
+from . import evolutionarytechniques
+from . import differentialevolution
+from . import simplextechniques
+from . import patternsearch
+from . import simulatedannealing
+from .pso import PSO, HybridParticle
+from . import globalGA
 register(AUCBanditMutationTechnique())
 
 register(AUCBanditMetaTechnique([

--- a/opentuner/search/composableevolutionarytechniques.py
+++ b/opentuner/search/composableevolutionarytechniques.py
@@ -1,14 +1,19 @@
+from __future__ import absolute_import
 import random
 import time
 import sys
 import json
 from fn import _
-from technique import all_techniques
-from technique import register
-from technique import register_generator
-from technique import SequentialSearchTechnique
-from manipulator import *
+from .technique import all_techniques
+from .technique import register
+from .technique import register_generator
+from .technique import SequentialSearchTechnique
+from .manipulator import *
 from opentuner.search.manipulator import Parameter
+from functools import reduce
+from six.moves import map
+import six
+from six.moves import range
 
 
 class PopulationMember(object):
@@ -27,11 +32,10 @@ class PopulationMember(object):
     self.timestamp = time.time()
 
 
-class ComposableEvolutionaryTechnique(SequentialSearchTechnique):
+class ComposableEvolutionaryTechnique(six.with_metaclass(abc.ABCMeta, SequentialSearchTechnique)):
   """
   An abstract base class for a technique that is composable with operators
   """
-  __metaclass__ = abc.ABCMeta
 
   # operator_map - from param-type to dict with operator name + list of arguments TODO
   # min_parent - minimum number of parents returned. Limits which operators can be used
@@ -354,7 +358,7 @@ class ComposableEvolutionaryTechnique(SequentialSearchTechnique):
     """
     generate a composable technique with random operators
     """
-    from manipulator import composable_operators
+    from .manipulator import composable_operators
     # randomly select a composable technique to generate
     t = cls(*args, **kwargs)
     if manipulator is None:
@@ -402,7 +406,7 @@ class RandomThreeParentsComposableTechnique(ComposableEvolutionaryTechnique):
     # copy oldest
     cfg = self.manipulator.copy(population[0].config)
 
-    shuffled_population = map(_.config, population[1:])
+    shuffled_population = list(map(_.config, population[1:]))
     # mix in the global best configuration
     shuffled_population += ([self.get_global_best_configuration()]
                             * self.information_sharing)

--- a/opentuner/search/differentialevolution.py
+++ b/opentuner/search/differentialevolution.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import
 import random
 import time
 import logging
 from fn import _
-from technique import register
-from technique import SearchTechnique
+from .technique import register
+from .technique import SearchTechnique
+from six.moves import map
+from six.moves import range
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.WARNING)
@@ -50,12 +53,11 @@ class DifferentialEvolution(SearchTechnique):
     self.population = [PopulationMember(
         self.driver.get_configuration(
             self.manipulator.random()), submitted=False)
-        for z in xrange(self.population_size)]
+        for z in range(self.population_size)]
 
   def oldest_pop_member(self):
     # since tests are run in parallel, exclude things with a replacement pending
-    pop_without_replacements = filter(lambda x: x.candidate_replacement is None,
-                                      self.population)
+    pop_without_replacements = [x for x in self.population if x.candidate_replacement is None]
     if not pop_without_replacements:
       # everything has a pending replacement
       return None
@@ -84,7 +86,7 @@ class DifferentialEvolution(SearchTechnique):
       return None
 
     config = None
-    for retry in xrange(self.duplicate_retries):
+    for retry in range(self.duplicate_retries):
       config = self.driver.get_configuration(
           self.create_new_configuration(oldest_pop_member))
       if not self.driver.has_results(config):
@@ -110,7 +112,7 @@ class DifferentialEvolution(SearchTechnique):
                        * self.information_sharing)
 
     random.shuffle(shuffled_pop)
-    x1, x2, x3 = map(_.config.data, shuffled_pop[0:3])
+    x1, x2, x3 = list(map(_.config.data, shuffled_pop[0:3]))
 
     use_f = random.random() / 2.0 + 0.5
 

--- a/opentuner/search/driver.py
+++ b/opentuner/search/driver.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import argparse
 import copy
 import logging
@@ -15,6 +17,7 @@ from opentuner.resultsdb.models import BanditSubTechnique
 from opentuner.search import plugin
 from opentuner.search import technique
 from opentuner.search.bandittechniques import AUCBanditMetaTechnique
+from six.moves import range
 
 log = logging.getLogger(__name__)
 
@@ -62,7 +65,7 @@ class SearchDriver(DriverBase):
     if self.args.list_techniques:
       techniques, generators = technique.all_techniques()
       for t in techniques:
-        print t.name
+        print(t.name)
       sys.exit(0)
 
     if self.args.generate_bandit_technique:
@@ -157,7 +160,7 @@ class SearchDriver(DriverBase):
   def run_generation_techniques(self):
     tests_this_generation = 0
     self.plugin_proxy.before_techniques()
-    for z in xrange(self.args.parallelism):
+    for z in range(self.args.parallelism):
       if self.seed_cfgs:
         config = self.get_configuration(self.seed_cfgs.pop())
         dr = DesiredResult(configuration=config,
@@ -241,7 +244,7 @@ class SearchDriver(DriverBase):
           rv = []
           for plugin in plugins:
             rv.append(getattr(plugin, method_name)(*args, **kwargs))
-          return filter(lambda x: x is not None, rv)
+          return [x for x in rv if x is not None]
 
         return plugin_method_proxy
 
@@ -261,7 +264,7 @@ class SearchDriver(DriverBase):
     no_tests_generations = 0
 
     # prime pipeline with tests
-    for z in xrange(self.args.pipelining):
+    for z in range(self.args.pipelining):
       self.run_generation_techniques()
       self.generation += 1
 

--- a/opentuner/search/evolutionarytechniques.py
+++ b/opentuner/search/evolutionarytechniques.py
@@ -1,8 +1,11 @@
+from __future__ import absolute_import
 import abc
 import copy
 import random
-from technique import SearchTechnique
+from .technique import SearchTechnique
 from opentuner.search import technique
+from six.moves import map
+from six.moves import range
 
 class EvolutionaryTechnique(SearchTechnique):
   def __init__(self,
@@ -28,15 +31,15 @@ class EvolutionaryTechnique(SearchTechnique):
     #TODO: set limit value
 
     parents = self.selection()
-    parents = map(copy.deepcopy, parents)
-    parent_hashes = map(self.manipulator.hash_config, parents)
+    parents = list(map(copy.deepcopy, parents))
+    parent_hashes = list(map(self.manipulator.hash_config, parents))
 
     if len(parents) > 1:
       cfg = self.crossover(parents)
     else:
       cfg = parents[0]
 
-    for z in xrange(10): #retries
+    for z in range(10): #retries
       self.mutation(cfg)
       if self.manipulator.hash_config(cfg) in parent_hashes:
         continue # try again

--- a/opentuner/search/globalGA.py
+++ b/opentuner/search/globalGA.py
@@ -1,8 +1,11 @@
+from __future__ import absolute_import
 import abc
 import copy
 import random
-from technique import SearchTechnique
+from .technique import SearchTechnique
 from opentuner.search import technique
+from six.moves import map
+from six.moves import range
 
 class GlobalEvolutionaryTechnique(SearchTechnique):
   def __init__(self,
@@ -29,15 +32,15 @@ class GlobalEvolutionaryTechnique(SearchTechnique):
     #TODO: set limit value
 
     parents = self.selection()
-    parents = map(copy.deepcopy, parents)
-    parent_hashes = map(self.manipulator.hash_config, parents)
+    parents = list(map(copy.deepcopy, parents))
+    parent_hashes = list(map(self.manipulator.hash_config, parents))
 
     if len(parents) > 1:
       cfg = self.crossover(parents)
     else:
       cfg = parents[0]
 
-    for z in xrange(10): #retries
+    for z in range(10): #retries
       self.mutation(cfg)
       if self.manipulator.hash_config(cfg) in parent_hashes:
         continue # try again

--- a/opentuner/search/manipulator.py
+++ b/opentuner/search/manipulator.py
@@ -233,10 +233,10 @@ class ConfigurationManipulator(ConfigurationManipulatorBase):
     params = list(self.parameters(config))
     params.sort(key=_.name)
     for i, p in enumerate(params):
-      m.update(str(p.name))
+      m.update(str(p.name).encode('utf-8'))
       m.update(p.hash_value(config))
-      m.update(str(i))
-      m.update("|")
+      m.update(str(i).encode('utf-8'))
+      m.update(b"|")
     return m.hexdigest()
 
   def search_space_size(self):
@@ -453,7 +453,7 @@ class PrimitiveParameter(six.with_metaclass(abc.ABCMeta, Parameter)):
   def hash_value(self, config):
     """produce unique hash for this value in the config"""
     self.normalize(config)
-    return hashlib.sha256(repr(self.get_value(config))).hexdigest()
+    return hashlib.sha256(repr(self.get_value(config)).encode('utf-8')).hexdigest().encode('utf-8')
 
   def copy_value(self, src, dst):
     """copy the value of this parameter from src to dst config"""
@@ -852,7 +852,7 @@ class ComplexParameter(Parameter):
   def hash_value(self, config):
     """produce unique hash for this value in the config"""
     self.normalize(config)
-    return hashlib.sha256(repr(self._get(config))).hexdigest()
+    return hashlib.sha256(repr(self._get(config)).encode('utf-8')).hexdigest().encode('utf-8')
 
   def get_value(self, config):
     return self._get(config)

--- a/opentuner/search/metatechniques.py
+++ b/opentuner/search/metatechniques.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import
 import abc
 import logging
 from collections import deque, defaultdict
 from fn import _
 
 from .technique import SearchTechniqueBase
+import sys
+from six.moves import zip
 
 log = logging.getLogger(__name__)
 
@@ -24,7 +27,7 @@ class MetaSearchTechnique(SearchTechniqueBase):
     for t in self.techniques:
       while t.name in names:
         t.name += '~'
-      t.name = intern(t.name)
+      t.name = sys.intern(t.name)
       names.add(t.name)
 
   def set_driver(self, driver):
@@ -68,7 +71,7 @@ class MetaSearchTechnique(SearchTechniqueBase):
   def debug_log(self):
     if self.log_freq and sum(self.logging_use_counters.values())>self.log_freq:
       log.info("%s: %s", self.name,
-          str(sorted(self.logging_use_counters.items(), key = _[1]*-1)))
+          str(sorted(list(self.logging_use_counters.items()), key = _[1]*-1)))
       self.logging_use_counters = defaultdict(int)
 
 class RoundRobinMetaSearchTechnique(MetaSearchTechnique):

--- a/opentuner/search/metatechniques.py
+++ b/opentuner/search/metatechniques.py
@@ -5,7 +5,10 @@ from collections import deque, defaultdict
 from fn import _
 
 from .technique import SearchTechniqueBase
-import sys
+try:
+    from sys import intern
+except ImportError:
+    pass
 from six.moves import zip
 
 log = logging.getLogger(__name__)
@@ -27,7 +30,7 @@ class MetaSearchTechnique(SearchTechniqueBase):
     for t in self.techniques:
       while t.name in names:
         t.name += '~'
-      t.name = sys.intern(t.name)
+      t.name = intern(t.name)
       names.add(t.name)
 
   def set_driver(self, driver):

--- a/opentuner/search/objective.py
+++ b/opentuner/search/objective.py
@@ -11,6 +11,9 @@ import six
 
 log = logging.getLogger(__name__)
 
+# somewhat like cmp in python2
+def cmp3(a,b):
+  return (a > b) - (a < b)
 
 class SearchObjective(six.with_metaclass(abc.ABCMeta, object)):
   """
@@ -165,11 +168,11 @@ class MinimizeTime(SearchObjective):
 
   def result_compare(self, result1, result2):
     """cmp() compatible comparison of resultsdb.models.Result"""
-    return cmp(result1.time, result2.time)
+    return cmp3(result1.time, result2.time)
 
   def config_compare(self, config1, config2):
     """cmp() compatible comparison of resultsdb.models.Configuration"""
-    return cmp(min(list(map(_.time, self.driver.results_query(config=config1)))),
+    return cmp3(min(list(map(_.time, self.driver.results_query(config=config1)))),
                min(list(map(_.time, self.driver.results_query(config=config2)))))
 
   def result_relative(self, result1, result2):
@@ -191,7 +194,7 @@ class MaximizeAccuracy(SearchObjective):
   def result_compare(self, result1, result2):
     """cmp() compatible comparison of resultsdb.models.Result"""
     # note opposite order
-    return cmp(result2.accuracy, result1.accuracy)
+    return cmp3(result2.accuracy, result1.accuracy)
 
   def result_relative(self, result1, result2):
     """return None, or a relative goodness of resultsdb.models.Result"""

--- a/opentuner/search/objective.py
+++ b/opentuner/search/objective.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import abc
 import logging
 
@@ -5,15 +6,16 @@ from fn import _
 
 import opentuner
 from opentuner.resultsdb.models import *
+from six.moves import map
+import six
 
 log = logging.getLogger(__name__)
 
 
-class SearchObjective(object):
+class SearchObjective(six.with_metaclass(abc.ABCMeta, object)):
   """
   delegates the comparison of results and configurations
   """
-  __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
   def result_order_by_terms(self):
@@ -103,7 +105,7 @@ class SearchObjective(object):
     if results.count() == 0:
       return None
     else:
-      return max(map(_.time, self.driver.results_query(config=config)))
+      return max(list(map(_.time, self.driver.results_query(config=config))))
 
 
   def project_compare(self, a1, a2, b1, b2, factor=1.0):
@@ -167,8 +169,8 @@ class MinimizeTime(SearchObjective):
 
   def config_compare(self, config1, config2):
     """cmp() compatible comparison of resultsdb.models.Configuration"""
-    return cmp(min(map(_.time, self.driver.results_query(config=config1))),
-               min(map(_.time, self.driver.results_query(config=config2))))
+    return cmp(min(list(map(_.time, self.driver.results_query(config=config1)))),
+               min(list(map(_.time, self.driver.results_query(config=config2)))))
 
   def result_relative(self, result1, result2):
     """return None, or a relative goodness of resultsdb.models.Result"""
@@ -275,11 +277,11 @@ class ThresholdAccuracyMinimizeTime(SearchObjective):
     results = self.driver.results_query(config=config)
     if results.count() == 0:
       return None
-    if self.accuracy_target > min(map(_.accuracy, results)):
+    if self.accuracy_target > min(list(map(_.accuracy, results))):
       m = self.low_accuracy_limit_multiplier
     else:
       m = 1.0
-    return m * max(map(_.time, results))
+    return m * max(list(map(_.time, results)))
 
 
   def filter_acceptable(self, query):

--- a/opentuner/search/patternsearch.py
+++ b/opentuner/search/patternsearch.py
@@ -1,5 +1,6 @@
 
 
+from __future__ import absolute_import
 from opentuner.search import technique
 
 class PatternSearch(technique.SequentialSearchTechnique):

--- a/opentuner/search/plugin.py
+++ b/opentuner/search/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import abc
 import argparse
 import logging
@@ -5,6 +7,8 @@ import time
 
 from datetime import datetime
 from fn import _
+from six.moves import map
+import six
 
 log = logging.getLogger(__name__)
 display_log = logging.getLogger(__name__ + ".DisplayPlugin")
@@ -57,8 +61,7 @@ class SearchPlugin(object):
     """
     pass
 
-class DisplayPlugin(SearchPlugin):
-  __metaclass__ = abc.ABCMeta
+class DisplayPlugin(six.with_metaclass(abc.ABCMeta, SearchPlugin)):
   def __init__(self, display_period=5):
     super(DisplayPlugin, self).__init__()
     self.last  = time.time()
@@ -117,14 +120,12 @@ class FileDisplayPlugin(SearchPlugin):
   def on_result(self, result):
     if self.out and result.time < self.last_best:
       self.last_best = result.time
-      print >>self.out, \
-          (result.collection_date - self.start_date).total_seconds(), \
-          result.time
+      print((result.collection_date - self.start_date).total_seconds(), \
+          result.time, file=self.out)
       self.out.flush()
     if self.details:
-      print >>self.details, \
-          (result.collection_date - self.start_date).total_seconds(), \
-          result.time
+      print((result.collection_date - self.start_date).total_seconds(), \
+          result.time, file=self.details)
       self.details.flush()
 
 def get_enabled(args):

--- a/opentuner/search/pso.py
+++ b/opentuner/search/pso.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=2 shiftwidth=2 softtabstop=2 expandtab autoindent smarttab
-from manipulator import *
+from __future__ import absolute_import
+from .manipulator import *
 from opentuner.search import technique
 import random
 import math
+from six.moves import range
 
 class PSO(technique.SequentialSearchTechnique ):
   """ Particle Swarm Optimization """

--- a/opentuner/search/simplextechniques.py
+++ b/opentuner/search/simplextechniques.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import abc
 import logging
 import math
@@ -7,6 +8,9 @@ from fn.iters import map, filter
 from .manipulator import Parameter
 from .metatechniques import RecyclingMetaTechnique
 from .technique import SequentialSearchTechnique, register
+from six.moves import filter
+from six.moves import map
+from six.moves import range
 
 log = logging.getLogger(__name__)
 
@@ -51,7 +55,7 @@ class SimplexTechnique(SequentialSearchTechnique):
     params = list(filter(Parameter.is_primitive,
                          self.manipulator.parameters(cfg)))
     params.sort(key=_.name)
-    return str(tuple(map(lambda x: x.get_unit_value(cfg), params)))
+    return str(tuple([x.get_unit_value(cfg) for x in params]))
 
   def debug_log(self):
     for i, config in enumerate(self.simplex_points):
@@ -120,7 +124,7 @@ class RightInitialMixin(object):
     cfg0 = self.initial_simplex_seed()
     simplex = [cfg0]
     params = self.manipulator.parameters(cfg0)
-    params = filter(lambda x: x.is_primitive(), params)
+    params = [x for x in params if x.is_primitive()]
     for p in params:
       simplex.append(self.manipulator.copy(cfg0))
       v = p.get_unit_value(simplex[-1])
@@ -146,7 +150,7 @@ class RegularInitialMixin(object):
     cfg0 = self.initial_simplex_seed()
     simplex = [cfg0]
     params = self.manipulator.parameters(cfg0)
-    params = list(filter(lambda x: x.is_primitive(), params))
+    params = list([x for x in params if x.is_primitive()])
     if len(params) == 0:
       return simplex
 
@@ -155,15 +159,15 @@ class RegularInitialMixin(object):
     p = q + ((1.0 / math.sqrt(2.0)) * self.initial_unit_edge_length)
 
     base = [x.get_unit_value(cfg0) for x in params]
-    for j in xrange(len(base)):
+    for j in range(len(base)):
       if max(p, q) + base[j] > 1.0:
         #flip this dimension as we would overflow our [0,1] bounds
         base[j] *= -1.0
 
-    for i in xrange(len(params)):
+    for i in range(len(params)):
       simplex.append(self.manipulator.copy(cfg0))
       params[i].set_unit_value(simplex[-1], abs(base[i] + p))
-      for j in xrange(i + 1, len(params)):
+      for j in range(i + 1, len(params)):
         params[j].set_unit_value(simplex[-1], abs(base[i] + q))
 
     return simplex
@@ -304,7 +308,7 @@ class NelderMead(SimplexTechnique):
     shrink the simplex in size by sigma=1/2 (default), moving it closer to the
     best point
     """
-    for i in xrange(1, len(self.simplex_points)):
+    for i in range(1, len(self.simplex_points)):
       self.simplex_points[i] = self.driver.get_configuration(
           self.linear_point(self.simplex_points[0].data,
                             self.simplex_points[i].data,
@@ -389,7 +393,7 @@ class Torczon(SimplexTechnique):
     reflected across self.simplex_points[0] by scale
     """
     simplex = list(self.simplex_points)  # shallow copy
-    for i in xrange(1, len(simplex)):
+    for i in range(1, len(simplex)):
       simplex[i] = self.driver.get_configuration(
           self.linear_point(simplex[0].data, simplex[i].data, scale))
       self.yield_nonblocking(simplex[i])

--- a/opentuner/search/simplextechniques.py
+++ b/opentuner/search/simplextechniques.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import abc
 import logging
 import math
+from functools import cmp_to_key
 from collections import defaultdict
 from fn import _
 from fn.iters import map, filter
@@ -227,7 +228,7 @@ class NelderMead(SimplexTechnique):
 
     while not self.convergence_criterea():
       # next steps assume this ordering
-      self.simplex_points.sort(cmp=objective.compare)
+      self.simplex_points.sort(key=cmp_to_key(objective.compare))
       # set limit from worst point
       self.limit = objective.limit_from_config(self.simplex_points[-1])
       self.centroid = self.calculate_centroid()
@@ -353,7 +354,7 @@ class Torczon(SimplexTechnique):
     for p in self.simplex_points:
       self.yield_nonblocking(p)
     yield None  # wait until results are ready
-    self.simplex_points.sort(cmp=objective.compare)
+    self.simplex_points.sort(key=cmp_to_key(objective.compare))
 
     while not self.convergence_criterea():
       # set limit from worst point
@@ -364,14 +365,14 @@ class Torczon(SimplexTechnique):
 
       reflected = self.reflected_simplex()
       yield None  # wait until results are ready
-      reflected.sort(cmp=objective.compare)
+      reflected.sort(key=cmp_to_key(objective.compare))
 
       # this next condition implies reflected[0] < simplex_points[0] since
       # reflected is sorted and contains simplex_points[0] (saves a db query)
       if reflected[0] is not self.simplex_points[0]:
         expanded = self.expanded_simplex()
         yield None  # wait until results are ready
-        expanded.sort(cmp=objective.compare)
+        expanded.sort(key=cmp_to_key(objective.compare))
 
         if objective.lt(expanded[0], reflected[0]):
           log.debug("expansion performed")

--- a/opentuner/search/simulatedannealing.py
+++ b/opentuner/search/simulatedannealing.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
 from opentuner.search import technique
 import math
 import random
+from six.moves import range
 #Default interval steps for cooling schedules
 DEFAULT_INTERVAL = 100
 

--- a/opentuner/search/technique.py
+++ b/opentuner/search/technique.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import abc
 import argparse
 import logging
@@ -10,7 +12,9 @@ from datetime import datetime
 from fn import _
 
 from opentuner.resultsdb.models import *
-from plugin import SearchPlugin
+from .plugin import SearchPlugin
+from six.moves import map
+import six
 
 log = logging.getLogger(__name__)
 #log.setLevel(logging.DEBUG)
@@ -23,11 +27,10 @@ argparser.add_argument('--list-techniques','-lt', action='store_true',
 argparser.add_argument('--generate-bandit-technique','-gbt', action='store_true',
                        help="randomly generate a bandit to use")
 
-class SearchTechniqueBase(object):
+class SearchTechniqueBase(six.with_metaclass(abc.ABCMeta, object)):
   """
   abstract base class for search techniques, with minimal interface
   """
-  __metaclass__ = abc.ABCMeta
 
   def __init__(self, name = None):
     super(SearchTechniqueBase, self).__init__()
@@ -192,7 +195,7 @@ class AsyncProceduralSearchTechnique(SearchTechnique):
       self.gen = self.call_main_generator()
     if not self.done:
       try:
-        return self.gen.next()
+        return next(self.gen)
       except StopIteration:
         log.debug("%s: generator finished", self.name)
         self.done = True
@@ -246,7 +249,7 @@ class SequentialSearchTechnique(AsyncProceduralSearchTechnique):
           self.rounds_since_novel_request = 0
         yield None # give other techniques a shot
       try:
-        p = subgen.next()
+        p = next(subgen)
         if p:
           self.pending_tests.append(p)
       except StopIteration:
@@ -267,8 +270,7 @@ class SequentialSearchTechnique(AsyncProceduralSearchTechnique):
           log.error("%s: still waiting for %d pending tests (c=%d)",
                      self.name, len(self.pending_tests), c)
 
-        self.pending_tests = filter(lambda x: not self.driver.has_results(x),
-                                    self.pending_tests)
+        self.pending_tests = [x for x in self.pending_tests if not self.driver.has_results(x)]
         if self.pending_tests:
           self.rounds_since_novel_request = 0
           yield False # wait
@@ -336,7 +338,7 @@ def get_enabled(args):
   techniques, generators = all_techniques()
   if args.list_techniques:
     for t in techniques:
-      print t.name
+      print(t.name)
     sys.exit(0)
 
   if not args.technique:
@@ -350,7 +352,7 @@ def get_enabled(args):
   return [t for t in techniques if t.name in args.technique]
 
 def get_root(args):
-  from metatechniques import RoundRobinMetaSearchTechnique
+  from .metatechniques import RoundRobinMetaSearchTechnique
   enabled = get_enabled(args)
   if len(enabled) == 1:
     return enabled[0]

--- a/opentuner/tuningrunmain.py
+++ b/opentuner/tuningrunmain.py
@@ -1,4 +1,6 @@
+from __future__ import print_function
 # vim: tabstop=2 shiftwidth=2 softtabstop=2 expandtab autoindent smarttab
+from __future__ import absolute_import
 import argparse
 import copy
 import inspect
@@ -92,7 +94,7 @@ class TuningRunMain(object):
 
     manipulator = measurement_interface.manipulator()
     if args.print_search_space_size:
-      print "10^{%.2f}" % math.log(manipulator.search_space_size(), 10)
+      print("10^{%.2f}" % math.log(manipulator.search_space_size(), 10))
       sys.exit(0)
     # show internal parameter representation
     if args.print_params:
@@ -107,8 +109,8 @@ class TuningRunMain(object):
         else:
           params_dict[cls] = [p]
       for k in params_dict:
-        print k, params_dict[k]
-        print
+        print(k, params_dict[k])
+        print()
       sys.exit(0)
 
     input_manager = measurement_interface.input_manager()

--- a/opentuner/utils/adddeps.py
+++ b/opentuner/utils/adddeps.py
@@ -1,4 +1,5 @@
 
+from __future__ import absolute_import
 import sys
 from os.path import normpath, realpath, dirname, join, isfile
 
@@ -7,7 +8,7 @@ project_root = normpath(join(dirname(realpath(__file__)), '../..'))
 if 'venv' not in ','.join(sys.path):
   venv_activate = join(project_root, 'venv/bin/activate_this.py')
   if isfile(venv_activate):
-    execfile(venv_activate, dict(__file__=venv_activate))
+    exec(compile(open(venv_activate).read(), venv_activate, 'exec'), dict(__file__=venv_activate))
 
 sys.path.insert(0, project_root)
 

--- a/opentuner/utils/compactdb.py
+++ b/opentuner/utils/compactdb.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 if __name__ == '__main__':
-  import adddeps
+  from . import adddeps
 
 import argparse
 import logging

--- a/opentuner/utils/dictconfig.py
+++ b/opentuner/utils/dictconfig.py
@@ -18,6 +18,7 @@
 # IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from __future__ import absolute_import
 import logging.handlers
 import re
 import sys
@@ -237,7 +238,7 @@ class BaseConfigurator(object):
     def configure_custom(self, config):
         """Configure an object with a user-supplied factory."""
         c = config.pop('()')
-        if not hasattr(c, '__call__') and hasattr(types, 'ClassType') and type(c) != types.ClassType:
+        if not hasattr(c, '__call__') and hasattr(types, 'ClassType') and type(c) != type:
             c = self.resolve(c)
         props = config.pop('.', None)
         # Check for valid identifiers
@@ -288,21 +289,21 @@ class DictConfigurator(BaseConfigurator):
                                 level = handler_config.get('level', None)
                                 if level:
                                     handler.setLevel(_checkLevel(level))
-                            except StandardError as e:
+                            except Exception as e:
                                 raise ValueError('Unable to configure handler '
                                                  '%r: %s' % (name, e))
                 loggers = config.get('loggers', EMPTY_DICT)
                 for name in loggers:
                     try:
                         self.configure_logger(name, loggers[name], True)
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure logger '
                                          '%r: %s' % (name, e))
                 root = config.get('root', None)
                 if root:
                     try:
                         self.configure_root(root, True)
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure root '
                                          'logger: %s' % e)
             else:
@@ -317,7 +318,7 @@ class DictConfigurator(BaseConfigurator):
                     try:
                         formatters[name] = self.configure_formatter(
                                                             formatters[name])
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure '
                                          'formatter %r: %s' % (name, e))
                 # Next, do filters - they don't refer to anything else, either
@@ -325,7 +326,7 @@ class DictConfigurator(BaseConfigurator):
                 for name in filters:
                     try:
                         filters[name] = self.configure_filter(filters[name])
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure '
                                          'filter %r: %s' % (name, e))
 
@@ -338,7 +339,7 @@ class DictConfigurator(BaseConfigurator):
                         handler = self.configure_handler(handlers[name])
                         handler.name = name
                         handlers[name] = handler
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure handler '
                                          '%r: %s' % (name, e))
                 # Next, do loggers - they refer to handlers and filters
@@ -377,7 +378,7 @@ class DictConfigurator(BaseConfigurator):
                         existing.remove(name)
                     try:
                         self.configure_logger(name, loggers[name])
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure logger '
                                          '%r: %s' % (name, e))
 
@@ -400,7 +401,7 @@ class DictConfigurator(BaseConfigurator):
                 if root:
                     try:
                         self.configure_root(root)
-                    except StandardError as e:
+                    except Exception as e:
                         raise ValueError('Unable to configure root '
                                          'logger: %s' % e)
         finally:
@@ -442,7 +443,7 @@ class DictConfigurator(BaseConfigurator):
         for f in filters:
             try:
                 filterer.addFilter(self.config['filters'][f])
-            except StandardError as e:
+            except Exception as e:
                 raise ValueError('Unable to add filter %r: %s' % (f, e))
 
     def configure_handler(self, config):
@@ -451,14 +452,14 @@ class DictConfigurator(BaseConfigurator):
         if formatter:
             try:
                 formatter = self.config['formatters'][formatter]
-            except StandardError as e:
+            except Exception as e:
                 raise ValueError('Unable to set formatter '
                                  '%r: %s' % (formatter, e))
         level = config.pop('level', None)
         filters = config.pop('filters', None)
         if '()' in config:
             c = config.pop('()')
-            if not hasattr(c, '__call__') and hasattr(types, 'ClassType') and type(c) != types.ClassType:
+            if not hasattr(c, '__call__') and hasattr(types, 'ClassType') and type(c) != type:
                 c = self.resolve(c)
             factory = c
         else:
@@ -468,7 +469,7 @@ class DictConfigurator(BaseConfigurator):
                 'target' in config:
                 try:
                     config['target'] = self.config['handlers'][config['target']]
-                except StandardError as e:
+                except Exception as e:
                     raise ValueError('Unable to set target handler '
                                      '%r: %s' % (config['target'], e))
             elif issubclass(klass, logging.handlers.SMTPHandler) and\
@@ -503,7 +504,7 @@ class DictConfigurator(BaseConfigurator):
         for h in handlers:
             try:
                 logger.addHandler(self.config['handlers'][h])
-            except StandardError as e:
+            except Exception as e:
                 raise ValueError('Unable to add handler %r: %s' % (h, e))
 
     def common_logger_config(self, logger, config, incremental=False):

--- a/opentuner/utils/stats_matplotlib.py
+++ b/opentuner/utils/stats_matplotlib.py
@@ -1,7 +1,13 @@
 #!usr/bin/python
 
+from __future__ import print_function
+from __future__ import absolute_import
+import six
+from six.moves import map
+from six.moves import range
+from six.moves import zip
 if __name__ == '__main__':
-  import adddeps
+  from . import adddeps
 
 import itertools
 import math
@@ -17,7 +23,7 @@ from fn import Stream
 from fn.iters import repeat
 from opentuner import resultsdb
 
-PCTSTEPS = map(_/20.0, xrange(21))
+PCTSTEPS = list(map(_/20.0, range(21)))
 
 
 def mean(vals):
@@ -65,8 +71,8 @@ def get_dbs(path, db_type='sqlite:///'):
       e, sm = resultsdb.connect(db_type + db_path)
       dbs.append(sm())
     except Exception as e:
-      print e
-      print "Error encountered while connecting to db"
+      print(e)
+      print("Error encountered while connecting to db")
   return dbs
 
 
@@ -95,9 +101,9 @@ def matplotlibplot_file(labels, xlim = None, ylim = None, disp_types=['median'])
         cols = [1]
         data = mean_values
       elif disp_type == 'all_percentiles':
-        cols = range(1,22)
+        cols = list(range(1,22))
 
-      plotted_data = [[] for x in xrange(len(cols))]
+      plotted_data = [[] for x in range(len(cols))]
 
       x_indices = []
       for data_point in data[1:]:
@@ -145,11 +151,11 @@ def combined_stats_over_time(label,
 
   by_run = [stats_over_time(session, run, extract_fn, combine_fn, no_data)
             for run, session in runs]
-  max_len = max(map(len, by_run))
+  max_len = max(list(map(len, by_run)))
 
   by_run_streams = [Stream() << x << repeat(x[-1], max_len-len(x))
                     for x in by_run]
-  by_quanta = zip(*by_run_streams[:])
+  by_quanta = list(zip(*by_run_streams[:]))
 
   # TODO: Fix this, this variable should be configurable
   stats_quanta = 10
@@ -252,10 +258,10 @@ def get_values(labels):
       dir_label_runs[run_label(tr)][run_label(tr)].append((tr, db))
   all_run_ids = list()
   returned_values = {}
-  for d, label_runs in dir_label_runs.iteritems():
-    all_run_ids = map(_[0].id, itertools.chain(*label_runs.values()))
-    session = label_runs.values()[0][0][1]
-    objective = label_runs.values()[0][0][0].objective
+  for d, label_runs in six.iteritems(dir_label_runs):
+    all_run_ids = list(map(_[0].id, itertools.chain(*list(label_runs.values()))))
+    session = list(label_runs.values())[0][0][1]
+    objective = list(label_runs.values())[0][0][0].objective
 
     q = (session.query(resultsdb.models.Result)
          .filter(resultsdb.models.Result.tuning_run_id.in_(all_run_ids))
@@ -287,4 +293,4 @@ def get_values(labels):
 if __name__ == '__main__':
     labels = [u'timeouts', u'always_reorder', u'add_store_at', u'all_options']
     get_values(labels)
-    print get_all_labels()
+    print(get_all_labels())

--- a/stats_app/manage.py
+++ b/stats_app/manage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import absolute_import
 import os
 import sys
 

--- a/stats_app/stats_app/settings.py
+++ b/stats_app/stats_app/settings.py
@@ -1,4 +1,5 @@
 # Django settings for stats_app project.
+from __future__ import absolute_import
 import os
 
 DEBUG = True

--- a/stats_app/stats_app/urls.py
+++ b/stats_app/stats_app/urls.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 from django.conf.urls import patterns, include, url
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
-import views.charts
+from . import views.charts
 admin.autodiscover()
 
 urlpatterns = patterns('',

--- a/stats_app/stats_app/views.py
+++ b/stats_app/stats_app/views.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from django.http import HttpResponse
 
 

--- a/stats_app/stats_app/views/charts.py
+++ b/stats_app/stats_app/views/charts.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import datetime
 import django
 from django.shortcuts import render

--- a/stats_app/stats_app/wsgi.py
+++ b/stats_app/stats_app/wsgi.py
@@ -13,6 +13,7 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
+from __future__ import absolute_import
 import os
 
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks

--- a/tests/test_manipulator.py
+++ b/tests/test_manipulator.py
@@ -1,14 +1,16 @@
+from __future__ import absolute_import
 import unittest
 import opentuner
 import mock
 import random
 import numpy
 from opentuner.search import manipulator
+from six.moves import range
 
 def faked_random(nums):
     f = fake_random(nums)
     def inner(*args, **kwargs):
-        return f.next()
+        return next(f)
     return inner
 
 def fake_random(nums):

--- a/tests/test_technique.py
+++ b/tests/test_technique.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 import opentuner
 import mock
@@ -7,7 +8,7 @@ from opentuner.search import manipulator
 def faked_random(nums):
   f = fake_random(nums)
   def inner(*args, **kwargs):
-    return f.next()
+    return next(f)
   return inner
 
 def fake_random(nums):


### PR DESCRIPTION
An alternative to #107, this one uses [python-modernize](https://python-modernize.readthedocs.io/en/latest/) instead of python future to address #103. Unlike the other pull request, this one doesn't require python2 users to install the any new packages (while #107 requires `pip install future`)

This pull request has two commits. One stemming from the automatic conversion script, and the other with my manual fixes for compatibility. 

P.S. I'm not trying to derail a LCTES (or otherwise) submission. There's no rush. 