### PR TITLE
Make installable on Python 3.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ argparse>=1.2.1
 fn>=0.2.12
 future
 numpy>=1.8.0
-pysqlite>=2.6.3
 SQLAlchemy>=0.8.2


### PR DESCRIPTION
The requirements file needs to remove:
`pysqlite>=2.6.3`
for this to be installable on python.  `pysqlite` won't install on python 3 because `sqlite` is already available.  Once, this change is made, opentuner seems to work on Python 3.