### PR TITLE
Fix issue #135

### DIFF
--- a/opentuner/driverbase.py
+++ b/opentuner/driverbase.py
@@ -25,6 +25,7 @@ class DriverBase(object):
                     generation=None,
                     objective_ordered=False,
                     config=None):
+    self.session.flush()
     q = self.session.query(Result)
     q = q.filter_by(tuning_run=self.tuning_run)
 


### PR DESCRIPTION
I've added a `self.session.flush()` at the [beginning of the](https://github.com/thiagotei/opentuner/blob/8dfb1c523b24c662743f63bb9d3019f867347428/opentuner/driverbase.py#L28) `results_query` function and the execution finished normally on Python 2.7 and 3.5. Tested using `./examples/rosenbrock/rosenbrock.py`.