### PR TITLE
Fixing hash_value function for ComplexParameter

### DIFF
--- a/opentuner/driverbase.py
+++ b/opentuner/driverbase.py
@@ -25,6 +25,7 @@ class DriverBase(object):
                     generation=None,
                     objective_ordered=False,
                     config=None):
+    self.session.flush()
     q = self.session.query(Result)
     q = q.filter_by(tuning_run=self.tuning_run)
 

--- a/opentuner/search/manipulator.py
+++ b/opentuner/search/manipulator.py
@@ -855,7 +855,7 @@ class ComplexParameter(Parameter):
   def hash_value(self, config):
     """produce unique hash for this value in the config"""
     self.normalize(config)
-    return hashlib.sha256(repr(self._get(config))).hexdigest()
+    return hashlib.sha256(repr(self.get_value(config)).encode('utf-8')).hexdigest().encode('utf-8')
 
   def get_value(self, config):
     return self._get(config)


### PR DESCRIPTION
The use of `encode` is required by `hashlib.sha256()` in Python 3.
This change was done for `PrimitiveParameter`, but not for `ComplexParameter `.