### PR TITLE
Remove dependence on fn

### DIFF
--- a/examples/halide/halidetuner.py
+++ b/examples/halide/halidetuner.py
@@ -35,7 +35,6 @@ import subprocess
 import tempfile
 import textwrap
 from io import StringIO
-from fn import _
 from pprint import pprint
 
 import opentuner

--- a/opentuner/search/composableevolutionarytechniques.py
+++ b/opentuner/search/composableevolutionarytechniques.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import time
 from functools import reduce
 
-from fn import _
 from future.utils import with_metaclass
 from past.builtins import cmp
 
@@ -403,12 +402,12 @@ class RandomThreeParentsComposableTechnique(ComposableEvolutionaryTechnique):
 
     def get_parents(self, population):
         self.use_f = random.random()
-        population.sort(key=_.timestamp)  # sort population by timestamp
+        population.sort(key = lambda x: x.timestamp)  # sort population by timestamp
 
         # copy oldest
         cfg = self.manipulator.copy(population[0].config)
 
-        shuffled_population = list(map(_.config, population[1:]))
+        shuffled_population = list(map(lambda x : x.config, population[1:]))
         # mix in the global best configuration
         shuffled_population += ([self.get_global_best_configuration()]
                                 * self.information_sharing)
@@ -419,7 +418,7 @@ class RandomThreeParentsComposableTechnique(ComposableEvolutionaryTechnique):
 
     def update_population(self, config, population):
         # replace the oldest configuration if the new one is better.
-        population.sort(key=_.timestamp)
+        population.sort(key = lambda x: x.timestamp)
         if self.lt(config, population[0].config):
             population[0].config = config
 
@@ -468,7 +467,7 @@ class GreedyComposableTechnique(ComposableEvolutionaryTechnique):
         return 4
 
     def get_parents(self, population):
-        population.sort(key=_.timestamp)  # sort population by timestamp
+        population.sort(key = lambda x: x.timestamp)  # sort population by timestamp
 
         # get a 50-50 mix of base and best cfgs as many operators do nothing given identical input cfgs
         cfg = self.manipulator.copy(population[0].config)
@@ -480,7 +479,7 @@ class GreedyComposableTechnique(ComposableEvolutionaryTechnique):
 
     def update_population(self, config, population):
         # replace the oldest configuration if the new one is better.
-        population.sort(key=_.timestamp)
+        population.sort(key = lambda x: x.timestamp)
         if self.lt(config, population[0].config):
             population[0].config = config
 

--- a/opentuner/search/differentialevolution.py
+++ b/opentuner/search/differentialevolution.py
@@ -8,7 +8,6 @@ from builtins import map
 from builtins import object
 from builtins import range
 
-from fn import _
 from past.utils import old_div
 
 from .technique import SearchTechnique
@@ -67,7 +66,7 @@ class DifferentialEvolution(SearchTechnique):
         if not pop_without_replacements:
             # everything has a pending replacement
             return None
-        pop_without_replacements.sort(key=_.timestamp)
+        pop_without_replacements.sort(key = lambda x: x.timestamp)
         return pop_without_replacements[0]
 
     def desired_configuration(self):
@@ -118,7 +117,7 @@ class DifferentialEvolution(SearchTechnique):
                              * self.information_sharing)
 
         random.shuffle(shuffled_pop)
-        x1, x2, x3 = list(map(_.config.data, shuffled_pop[0:3]))
+        x1, x2, x3 = list(map(lambda x: x.config.data, shuffled_pop[0:3]))
 
         use_f = old_div(random.random(), 2.0) + 0.5
 

--- a/opentuner/search/driver.py
+++ b/opentuner/search/driver.py
@@ -9,8 +9,6 @@ from builtins import object
 from builtins import range
 from datetime import datetime
 
-from fn import _
-
 from opentuner.driverbase import DriverBase
 from opentuner.resultsdb.models import BanditInfo
 from opentuner.resultsdb.models import BanditSubTechnique
@@ -102,13 +100,13 @@ class SearchDriver(DriverBase):
             else:
                 log.error('no such file for --seed-configuration %s', cfg_filename)
 
-        self.plugins.sort(key=_.priority)
+        self.plugins.sort(key = lambda x: x.priority)
 
     def add_plugin(self, p):
         if p in self.plugins:
             return
         self.plugins.append(p)
-        self.plugins.sort(key=_.priority)
+        self.plugins.sort(key = lambda x: x.priority)
         p.set_driver(self)
 
     def convergence_criteria(self):

--- a/opentuner/search/manipulator.py
+++ b/opentuner/search/manipulator.py
@@ -20,7 +20,6 @@ from builtins import str
 from functools import reduce
 
 import numpy
-from fn import _
 from future.utils import with_metaclass
 from past.utils import old_div
 
@@ -44,7 +43,7 @@ class ConfigurationManipulatorBase(with_metaclass(abc.ABCMeta, object)):
 
     def validate(self, config):
         """is the given config valid???"""
-        return all(map(_.validate(config), self.parameters(config)))
+        return all(map(lambda x: x.validate(config), self.parameters(config)))
 
     def normalize(self, config):
         """mutate config into canonical form"""
@@ -66,7 +65,7 @@ class ConfigurationManipulatorBase(with_metaclass(abc.ABCMeta, object)):
     def param_names(self, *args):
         """return union of parameter names in args"""
         return sorted(reduce(set.union,
-                             [set(map(_.name, self.parameters(cfg)))
+                             [set(map(lambda x: x.name, self.parameters(cfg)))
                               for cfg in args]))
 
     def linear_config(self, a, cfg_a, b, cfg_b, c, cfg_c):
@@ -235,7 +234,7 @@ class ConfigurationManipulator(ConfigurationManipulatorBase):
         """produce unique hash value for the given config"""
         m = hashlib.sha256()
         params = list(self.parameters(config))
-        params.sort(key=_.name)
+        params.sort(key = lambda x: x.name)
         for i, p in enumerate(params):
             m.update(str(p.name).encode())
             m.update(p.hash_value(config))
@@ -245,7 +244,7 @@ class ConfigurationManipulator(ConfigurationManipulatorBase):
 
     def search_space_size(self):
         """estimate the size of the search space, not precise"""
-        return reduce(_ * _, [x.search_space_size() for x in self.params])
+        return reduce(lambda a, b: a * b, [x.search_space_size() for x in self.params])
 
     def difference(self, cfg1, cfg2):
         cfg = self.copy(cfg1)

--- a/opentuner/search/metatechniques.py
+++ b/opentuner/search/metatechniques.py
@@ -5,7 +5,6 @@ from builtins import str
 from builtins import zip
 from collections import deque, defaultdict
 
-from fn import _
 from past.builtins import cmp
 
 from .technique import SearchTechniqueBase
@@ -75,7 +74,7 @@ class MetaSearchTechnique(SearchTechniqueBase):
     def debug_log(self):
         if self.log_freq and sum(self.logging_use_counters.values()) > self.log_freq:
             log.info("%s: %s", self.name,
-                     str(sorted(list(self.logging_use_counters.items()), key=_[1] * -1)))
+                     str(sorted(list(self.logging_use_counters.items()), key = lambda x: x[1] * -1)))
             self.logging_use_counters = defaultdict(int)
 
 

--- a/opentuner/search/objective.py
+++ b/opentuner/search/objective.py
@@ -4,7 +4,6 @@ import abc
 import logging
 from builtins import map
 
-from fn import _
 from future.utils import with_metaclass
 from past.builtins import cmp
 from past.utils import old_div
@@ -108,7 +107,7 @@ class SearchObjective(with_metaclass(abc.ABCMeta, object)):
         if results.count() == 0:
             return None
         else:
-            return max(list(map(_.time, self.driver.results_query(config=config))))
+            return max(list(map(lambda x: x.time, self.driver.results_query(config=config))))
 
     def project_compare(self, a1, a2, b1, b2, factor=1.0):
         """
@@ -171,8 +170,8 @@ class MinimizeTime(SearchObjective):
 
     def config_compare(self, config1, config2):
         """cmp() compatible comparison of resultsdb.models.Configuration"""
-        return cmp(min(list(map(_.time, self.driver.results_query(config=config1)))),
-                   min(list(map(_.time, self.driver.results_query(config=config2)))))
+        return cmp(min(list(map(lambda x: x.time, self.driver.results_query(config=config1)))),
+                   min(list(map(lambda x: x.time, self.driver.results_query(config=config2)))))
 
     def result_relative(self, result1, result2):
         """return None, or a relative goodness of resultsdb.models.Result"""
@@ -279,11 +278,11 @@ class ThresholdAccuracyMinimizeTime(SearchObjective):
         results = self.driver.results_query(config=config)
         if results.count() == 0:
             return None
-        if self.accuracy_target > min(list(map(_.accuracy, results))):
+        if self.accuracy_target > min(list(map(lambda x: x.accuracy, results))):
             m = self.low_accuracy_limit_multiplier
         else:
             m = 1.0
-        return m * max(list(map(_.time, results)))
+        return m * max(list(map(lambda x: x.time, results)))
 
     def filter_acceptable(self, query):
         """Return a Result() query that only returns acceptable results"""

--- a/opentuner/search/plugin.py
+++ b/opentuner/search/plugin.py
@@ -8,7 +8,6 @@ from builtins import map
 from builtins import object
 from datetime import datetime
 
-from fn import _
 from future.utils import with_metaclass
 
 log = logging.getLogger(__name__)
@@ -98,7 +97,7 @@ class LogDisplayPlugin(DisplayPlugin):
         if best is None:
             log.warning("no results yet")
             return
-        requestor = ','.join(map(_.requestor, best.desired_results))
+        requestor = ','.join(map(lambda x: x.requestor, best.desired_results))
         display_log.info("tests=%d, best %s, cost %s, found by %s",
                          count,
                          cfg_repr(best.configuration),

--- a/opentuner/search/simplextechniques.py
+++ b/opentuner/search/simplextechniques.py
@@ -11,8 +11,6 @@ from builtins import str
 from collections import defaultdict
 from functools import cmp_to_key
 
-from fn import _
-from fn.iters import map, filter
 from past.utils import old_div
 
 from .manipulator import Parameter
@@ -61,7 +59,7 @@ class SimplexTechnique(SequentialSearchTechnique):
     def cfg_to_str(self, cfg):
         params = list(filter(Parameter.is_primitive,
                              self.manipulator.parameters(cfg)))
-        params.sort(key=_.name)
+        params.sort(key = lambda x: x.name)
         return str(tuple([x.get_unit_value(cfg) for x in params]))
 
     def debug_log(self):

--- a/opentuner/search/technique.py
+++ b/opentuner/search/technique.py
@@ -13,7 +13,6 @@ from builtins import str
 from datetime import datetime
 from importlib import import_module
 
-from fn import _
 from future.utils import with_metaclass
 
 from opentuner.resultsdb.models import *
@@ -360,7 +359,7 @@ def get_enabled(args):
         # no techniques specified, default technique
         args.technique = ['AUCBanditMetaTechniqueA']
 
-    for unknown in set(args.technique) - set(map(_.name, techniques)):
+    for unknown in set(args.technique) - set(map(lambda x: x.name, techniques)):
         log.error('unknown technique %s', unknown)
         raise Exception('Unknown technique: --technique={}'.format(unknown))
 

--- a/opentuner/utils/stats_matplotlib.py
+++ b/opentuner/utils/stats_matplotlib.py
@@ -23,12 +23,10 @@ import sqlalchemy
 import sqlalchemy.orm.exc
 
 from collections import defaultdict
-from fn import _
-from fn import Stream
-from fn.iters import repeat
+from itertools import chain, repeat
 from opentuner import resultsdb
 
-PCTSTEPS = list(map(old_div(_, 20.0), list(range(21))))
+PCTSTEPS = list(map(lambda n: old_div(n, 20.0), list(range(21))))
 
 
 def mean(vals):
@@ -150,7 +148,7 @@ def combined_stats_over_time(label,
     combine stats_over_time() vectors for multiple runs
     """
 
-    extract_fn = _.result.time
+    extract_fn = lambda x: x.result.time
     combine_fn = min
     no_data = 999
 
@@ -158,7 +156,7 @@ def combined_stats_over_time(label,
               for run, session in runs]
     max_len = max(list(map(len, by_run)))
 
-    by_run_streams = [Stream() << x << repeat(x[-1], max_len - len(x))
+    by_run_streams = [chain(x, repeat(x[-1], max_len - len(x)))
                       for x in by_run]
     by_quanta = list(zip(*by_run_streams[:]))
 
@@ -266,7 +264,7 @@ def get_values(labels):
     all_run_ids = list()
     returned_values = {}
     for d, label_runs in list(dir_label_runs.items()):
-        all_run_ids = list(map(_[0].id, itertools.chain(*list(label_runs.values()))))
+        all_run_ids = list(map(lambda x: x[0].id, chain(*list(label_runs.values()))))
         session = list(label_runs.values())[0][0][1]
         objective = list(label_runs.values())[0][0][0].objective
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 argparse>=1.2.1
-fn>=0.2.12
 future
 numpy>=1.8.0
 SQLAlchemy>=0.8.2


### PR DESCRIPTION
The Python package `fn` (https://github.com/kachayev/fn.py) is not actively maintained and OpenTuner only uses it for the `_` shortcut for creating lambdas and the `Stream` class for concatenating iterators. More importantly, `fn` is incompatible with Python 3.9+ (https://github.com/kachayev/fn.py/issues/86, https://github.com/kachayev/fn.py/issues/91). This patch rewrites the uses of `fn` in OpenTuner and removes the dependence.