### PR TITLE
Fix PseudoAnnealingSearch and Torczon techniques

### DIFF
--- a/opentuner/search/simplextechniques.py
+++ b/opentuner/search/simplextechniques.py
@@ -356,7 +356,7 @@ class Torczon(SimplexTechnique):
         for p in self.simplex_points:
             self.yield_nonblocking(p)
         yield None  # wait until results are ready
-        self.simplex_points.sort(cmp=objective.compare)
+        self.simplex_points.sort(key=cmp_to_key(objective.compare))
 
         while not self.convergence_criterea():
             # set limit from worst point
@@ -367,14 +367,14 @@ class Torczon(SimplexTechnique):
 
             reflected = self.reflected_simplex()
             yield None  # wait until results are ready
-            reflected.sort(cmp=objective.compare)
+            reflected.sort(key=cmp_to_key(objective.compare))
 
             # this next condition implies reflected[0] < simplex_points[0] since
             # reflected is sorted and contains simplex_points[0] (saves a db query)
             if reflected[0] is not self.simplex_points[0]:
                 expanded = self.expanded_simplex()
                 yield None  # wait until results are ready
-                expanded.sort(cmp=objective.compare)
+                expanded.sort(key=cmp_to_key(objective.compare))
 
                 if objective.lt(expanded[0], reflected[0]):
                     log.debug("expansion performed")
@@ -385,7 +385,7 @@ class Torczon(SimplexTechnique):
             else:
                 contracted = self.contracted_simplex()
                 yield None  # wait until results are ready
-                contracted.sort(cmp=objective.compare)
+                contracted.sort(key=cmp_to_key(objective.compare))
 
                 log.debug("contraction performed")
                 self.simplex_points = contracted

--- a/opentuner/search/simulatedannealing.py
+++ b/opentuner/search/simulatedannealing.py
@@ -3,6 +3,7 @@ from __future__ import division
 import math
 import random
 from builtins import range
+from functools import cmp_to_key
 
 from past.utils import old_div
 
@@ -105,7 +106,7 @@ class PseudoAnnealingSearch(technique.SequentialSearchTechnique):
             # No relative compare
             else:
                 # sort points by "energy" (quality)
-                points.sort(cmp=objective.compare)
+                points.sort(key=cmp_to_key(objective.compare))
 
                 # Make decision about changing state
                 # probability picking next-best state is exp^(-1/temp)


### PR DESCRIPTION
Since Python 3.x the .sort(...) function cannot take a parameter cmp anymore. Some techniques were updated to to use .sort(key=cmp_to_key(objective.compare)), but this update was missing from these 2 techniques. This patch adds it to both techniques and allows their use with Python 3.x.