### PR TITLE
Add cpython_pyperformance example for autotuning CPython compiler/linker flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+**/__pycache__/**
 
 # C extensions
 *.so

--- a/examples/cpython_pyperformance/cpython_pyperformance.py
+++ b/examples/cpython_pyperformance/cpython_pyperformance.py
@@ -67,7 +67,13 @@ Notes:
   opentuner.db);
 * each configuration's dependencies go into its own venv, but pip hits the
   local cache (no repeated network download); the venv is removed after each
-  run by default, use ``--keep-venv`` to keep it.
+  run by default, use ``--keep-venv`` to keep it;
+* the out-of-tree build artifacts (object files, generated sources) are removed
+  right after each run, keeping only the installed interpreter and run logs so
+  a re-measurement can reuse the cached build; once tuning completes the
+  remaining ``build-<id>/`` directories are removed but the best
+  configuration's installed interpreter is kept for the final comparison -- use
+  ``--keep-builds`` to keep them all.
 """
 
 from __future__ import print_function
@@ -76,6 +82,7 @@ import json
 import logging
 import math
 import os
+import re
 import shlex
 import shutil
 
@@ -338,6 +345,14 @@ class CpythonTuner(MeasurementInterface):
         if not self.args.keep_venv and os.path.isdir(venv_dir):
             shutil.rmtree(venv_dir, ignore_errors=True)
 
+        # Delete the out-of-tree build tree right after this run instead of
+        # waiting for the whole tuning session to end: the object files and
+        # generated sources are large and would otherwise exhaust disk space
+        # across many iterations. install/ and the logs are kept so a
+        # re-measurement of the same configuration can reuse the cached build.
+        if not self.args.keep_builds:
+            self._cleanup_build_intermediates(build_dir)
+
         if status != "OK":
             return Result(state=status, time=float("inf"))
 
@@ -380,9 +395,55 @@ class CpythonTuner(MeasurementInterface):
         print("  CFLAGS =", cflags)
         print("  LDFLAGS =", ldflags)
 
+        # Preserve the best configuration's installed interpreter so it can be
+        # used directly for the final comparison without a rebuild. The build
+        # cache maps (cflags, ldflags) to the build dir that produced it.
+        cached = self._build_cache.get((cflags, ldflags))
+        keep = ()
+        if cached is not None:
+            keep = (os.path.basename(cached[0]),)
+            print("  tuned python:", cached[1])
+
+        # Delete the intermediate build directories now that tuning is done,
+        # keeping the best one.
+        if not self.args.keep_builds:
+            self._cleanup_build_dirs(keep=keep)
+
     # ------------------------------------------------------------------
     # Utilities
     # ------------------------------------------------------------------
+    def _cleanup_build_intermediates(self, build_dir):
+        """Delete the out-of-tree build tree, keeping install/ and the logs.
+
+        After ``make install`` the interpreter under install/ is self-contained,
+        so the object files and generated sources in build_dir are no longer
+        needed; keeping install/ lets a re-measurement reuse the cached build.
+        """
+        keep = ("install", "build.log", "pyperformance.log", "pyperformance.json")
+        if not os.path.isdir(build_dir):
+            return
+        for name in os.listdir(build_dir):
+            if name in keep:
+                continue
+            path = os.path.join(build_dir, name)
+            if os.path.islink(path) or os.path.isfile(path):
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+            elif os.path.isdir(path):
+                shutil.rmtree(path, ignore_errors=True)
+
+    def _cleanup_build_dirs(self, keep=()):
+        """Remove all build-<id> directories under --build-root, except `keep`."""
+        build_root = os.path.abspath(self.args.build_root)
+        if not os.path.isdir(build_root):
+            return
+        for name in os.listdir(build_root):
+            if re.fullmatch(r"build-\d+", name) and name not in keep:
+                shutil.rmtree(os.path.join(build_root, name), ignore_errors=True)
+                log.info("removed intermediate build directory %s", name)
+
     @staticmethod
     def _tail(path, n=40):
         try:
@@ -428,6 +489,10 @@ def _add_args(argparser):
     argparser.add_argument(
         "--output-dir", default=".",
         help="directory for the best-configuration output")
+    argparser.add_argument(
+        "--keep-builds", action="store_true",
+        help="keep intermediate build directories after tuning completes "
+             "(removed by default)")
     return argparser
 
 

--- a/examples/cpython_pyperformance/cpython_pyperformance.py
+++ b/examples/cpython_pyperformance/cpython_pyperformance.py
@@ -1,60 +1,73 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-使用 OpenTuner 自动调优 CPython 的 GCC 编译 / 链接选项,以 pyperformance 作为评测目标。
+Use OpenTuner to autotune CPython's GCC compile/link options, using
+pyperformance as the objective.
 
-原理
-----
-CPython 的 Makefile 里最终编译命令为::
+How it works
+------------
+CPython's final compile command in the generated Makefile is::
 
     $(CC) ... $(BASECFLAGS) $(OPT) $(CONFIGURE_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) ...
-    $(CC) ... $(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST) ...   # NODIST 部分在最后
+    $(CC) ... $(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST) ...   # NODIST comes last
 
-其中:
-* ``OPT``              由 ``--enable-optimizations`` 决定,实际是 ``-DNDEBUG -g -fwrapv -O3 -Wall``;
-* ``CONFIGURE_CFLAGS`` 就是你 configure 时通过环境变量 ``CFLAGS`` 传入的值;
-* ``CONFIGURE_LDFLAGS`` 同理来自环境变量 ``LDFLAGS``;
-* ``CONFIGURE_CFLAGS_NODIST`` / ``CONFIGURE_LDFLAGS_NODIST`` 里是 configure 自己追加的
-  ``-fno-semantic-interposition -flto -fuse-linker-plugin -ffat-lto-objects
-  -flto-partition=none`` 等(由 ``--with-lto`` 决定)。
+where:
+* ``OPT``                       is set by ``--enable-optimizations`` and is
+  effectively ``-DNDEBUG -g -fwrapv -O3 -Wall``;
+* ``CONFIGURE_CFLAGS``          is whatever you pass via the ``CFLAGS``
+  environment variable at configure time;
+* ``CONFIGURE_LDFLAGS``         likewise comes from the ``LDFLAGS`` env var;
+* ``CONFIGURE_CFLAGS_NODIST`` / ``CONFIGURE_LDFLAGS_NODIST`` hold flags
+  appended by configure itself (``-fno-semantic-interposition -flto
+  -fuse-linker-plugin -ffat-lto-objects -flto-partition=none``, etc.), driven
+  by ``--with-lto``.
 
-由于 ``CONFIGURE_CFLAGS`` 位于 ``OPT``(-O3)*之后*,所以在 ``CFLAGS`` 里放 ``-O2`` 会
-真正覆盖掉 ``-O3``;而我们想调优的 ``-f`` / ``--param`` / ``-march`` 选项也都放在
-``CFLAGS`` 里,位置同样在 NODIST 之前、不会和 LTO/PGO 冲突。
+Because ``CONFIGURE_CFLAGS`` appears *after* ``OPT`` (``-O3``), putting ``-O2``
+in ``CFLAGS`` really does override ``-O3``; likewise the ``-f`` / ``--param`` /
+``-march`` options we tune are placed in ``CFLAGS`` before the NODIST part, so
+they do not conflict with LTO/PGO.
 
-注意:``-fno-semantic-interposition`` 和 ``-flto-partition=none`` 已经被
-``--with-lto`` / ``--enable-optimizations`` 固定追加到 NODIST 里,并且位于用户
-CFLAGS 之后,因此无法通过 CFLAGS 覆盖,本脚本也就不把它们列为可调参数。
+Note: ``-fno-semantic-interposition`` and ``-flto-partition=none`` are already
+appended to NODIST by ``--with-lto`` / ``--enable-optimizations`` and come
+after the user CFLAGS, so they cannot be overridden via ``CFLAGS`` and are
+intentionally left out of the search space.
 
-每个配置会:
-  1. 在独立的 build 目录里 configure + make + make install 出一个 python3.10;
-  2. 用宿主机上的 pyperformance 对刚编译出的解释器跑基准;
-  3. 读取 pyperformance 输出的 JSON,取所有 benchmark 中位数的几何平均作为分数
-     (越小越快),返回给 OpenTuner。
+For each configuration the tuner:
+  1. builds a python3.10 out-of-tree via configure + make + make install;
+  2. runs pyperformance on that interpreter using the host python;
+  3. parses the pyperformance JSON output and scores the run as the geometric
+     mean of all benchmark medians (lower is faster), which is returned to
+     OpenTuner.
 
-用法示例
---------
-    python3 cpython_pyperformance.py \
-        --source-dir ~/gerrit/cpython \
-        --build-root ./builds \
-        --pyperformance-python python3 \
-        --benchmarks 2to3,chameleon,django_template,json_loads,regex_compile \
-        --fast \
-        --jobs 16 \
-        --parallelism 1 \
+Usage
+-----
+    python3 cpython_pyperformance.py \\
+        --source-dir ~/gerrit/cpython \\
+        --build-root ./builds \\
+        --pyperformance-python python3 \\
+        --benchmarks 2to3,chameleon,django_template,json_loads,regex_compile \\
+        --fast \\
+        --jobs 16 \\
+        --parallelism 1 \\
         --test-limit 200
 
-说明:
-* ``--fast``            让 pyperformance 用快速模式(每项只测一个值),大幅缩短单次采样;
-* ``--benchmarks``      只跑一小批有代表性的 benchmark,进一步缩短采样时间;
-* ``--test-limit N``    调优到第 N 个采样后停止(本 fork 里是“采样个数”,不是超时);
-                        也可用 ``--stop-after SECONDS`` 按墙钟时间停止;
-* ``--parallelism 1``   一次只 build 一个配置,避免并行 make 互相抢占 CPU;
-* 单个配置的 build / 跑分超时由 ``--build-timeout`` / ``--run-timeout`` 控制
-  (本 fork 的 ``--test-limit`` 已不再是单次超时,见上);
-* 中断后重新运行会自动续跑(结果保存在 opentuner.db 里)。
-* 每个配置的依赖会装到各自 venv 里,但 pip 会命中本地缓存,不会重复联网下载;
-  跑完默认删除 venv 以节省磁盘,可用 ``--keep-venv`` 保留。
+Notes:
+* ``--fast``            tell pyperformance to use fast mode (one value per
+                        benchmark), greatly shortening each sample;
+* ``--benchmarks``      run only a small representative subset of benchmarks;
+* ``--test-limit N``    stop after N samples (in this fork it is a test count,
+                        not a timeout); you can also use ``--stop-after SECONDS``
+                        to stop by wall-clock time;
+* ``--parallelism 1``   build one configuration at a time so parallel makes
+                        don't thrash the CPU;
+* per-configuration build/run timeouts are controlled by ``--build-timeout`` /
+  ``--run-timeout`` (this fork's ``--test-limit`` is no longer a per-test
+  timeout, see above);
+* re-running after an interrupt resumes automatically (results are stored in
+  opentuner.db);
+* each configuration's dependencies go into its own venv, but pip hits the
+  local cache (no repeated network download); the venv is removed after each
+  run by default, use ``--keep-venv`` to keep it.
 """
 
 from __future__ import print_function
@@ -77,34 +90,36 @@ log = logging.getLogger("cpython_pyperformance")
 
 
 # ---------------------------------------------------------------------------
-# 可调优的 GCC -f 编译选项。
-# 每个选项取值 on / off / default:
-#   on       -> -f<flag>
-#   off      -> -fno-<flag>
-#   default  -> 不显式指定(交给 -O3 的默认行为)
-# 这里刻意只挑了对 CPython 性能可能有影响、且 -fno- 形式都合法的选项,避免构建失败。
+# Tunable GCC -f compile flags (stored here without the leading "f").
+# Each flag takes on / off / default:
+#   on       -> -f<flag>      (e.g. unroll-loops -> -funroll-loops)
+#   off      -> -fno-<flag>   (e.g. unroll-loops -> -fno-unroll-loops)
+#   default  -> not specified (leave it to -O3's default behavior)
+# Only flags that plausibly affect CPython performance and whose -fno- form is
+# valid are listed here, to avoid build failures.
 # ---------------------------------------------------------------------------
 COMPILE_FLAGS = [
-    "funroll-loops",
-    "fipa-pta",
-    "ftree-vectorize",
-    "fomit-frame-pointer",
-    "fpredictive-commoning",
-    "fgcse-after-reload",
-    "freorder-blocks-and-partition",
-    "fdevirtualize-speculatively",
-    "fgraphite-identity",
-    "ftracer",
-    "ftree-loop-distribute-patterns",
-    "finline-functions",
+    "unroll-loops",
+    "ipa-pta",
+    "tree-vectorize",
+    "omit-frame-pointer",
+    "predictive-commoning",
+    "gcse-after-reload",
+    "reorder-blocks-and-partition",
+    "devirtualize-speculatively",
+    "graphite-identity",
+    "tracer",
+    "tree-loop-distribute-patterns",
+    "inline-functions",
 ]
 
-# (名字, 最小值, 最大值) 的 GCC --param 参数。
+# GCC --param parameters as (name, min, max). Ranges must match
+# `gcc --help=params`, otherwise GCC errors with "not between 0 and N".
 GCC_PARAMS = [
     ("early-inlining-insns", 0, 300),
     ("inline-unit-growth", 0, 100),
     ("max-inline-insns-auto", 0, 100),
-    ("predictable-branch-outcome", 0, 100),
+    ("predictable-branch-outcome", 0, 50),  # gcc 11 valid range is <0,50>
 ]
 
 
@@ -112,18 +127,21 @@ class CpythonTuner(MeasurementInterface):
     def __init__(self, *pargs, **kwargs):
         kwargs.setdefault("program_name", "cpython")
         super(CpythonTuner, self).__init__(*pargs, **kwargs)
-        # 以 (cflags, ldflags) 为 key 的构建缓存,避免同一配置重复 build。
+        # Build cache keyed by (cflags, ldflags) to avoid rebuilding the same
+        # configuration twice.
         self._build_cache = {}
 
     # ------------------------------------------------------------------
-    # 搜索空间
+    # Search space
     # ------------------------------------------------------------------
     def manipulator(self):
         manipulator = ConfigurationManipulator()
 
-        # 优化等级。放在 CFLAGS 里,位置在 OPT(-O3) 之后,可以真正覆盖它。
+        # Optimization level. Placed in CFLAGS, after OPT (-O3), so it really
+        # overrides the default.
         manipulator.add_parameter(EnumParameter("opt", ["-O2", "-O3"]))
-        # 是否针对本机 CPU 微架构(-march=native / -mtune=native)。
+        # Whether to target the local CPU microarchitecture
+        # (-march=native / -mtune=native).
         manipulator.add_parameter(EnumParameter("march", ["default", "native"]))
 
         for flag in COMPILE_FLAGS:
@@ -136,7 +154,7 @@ class CpythonTuner(MeasurementInterface):
         return manipulator
 
     # ------------------------------------------------------------------
-    # 把配置转成 CFLAGS / LDFLAGS 字符串
+    # Turn a configuration into CFLAGS / LDFLAGS strings
     # ------------------------------------------------------------------
     def _cfg_to_cflags(self, cfg):
         flags = [cfg["opt"]]
@@ -156,27 +174,32 @@ class CpythonTuner(MeasurementInterface):
         return " ".join(flags)
 
     def _cfg_to_ldflags(self, cfg):
-        # 链接阶段目前没有额外可调项(如需,可在此扩展,例如 -Wl,-O1 等)。
+        # No extra link-stage options for now; extend here if needed
+        # (e.g. -Wl,-O1).
         return ""
 
     # ------------------------------------------------------------------
-    # 构建 CPython
+    # Build CPython
     # ------------------------------------------------------------------
     def _build(self, build_dir, cflags, ldflags):
+        build_dir = os.path.abspath(build_dir)
         prefix = os.path.join(build_dir, "install")
         configure = os.path.join(self.args.source_dir, "configure")
         logfile = os.path.join(build_dir, "build.log")
 
         os.makedirs(build_dir, exist_ok=True)
 
+        # Run cd/configure/make/make install inside a subshell so the whole
+        # output is redirected to build.log, making configure/make failures
+        # visible in the log.
         cmd = (
-            "set -e; "
+            "( set -e; "
             "cd {build_dir}; "
             "export CFLAGS={cflags}; "
             "export LDFLAGS={ldflags}; "
             "{configure} --prefix={prefix} {configure_flags}; "
             "make -j{jobs}; "
-            "make install"
+            "make install ) > {log} 2>&1"
         ).format(
             build_dir=shlex.quote(build_dir),
             cflags=shlex.quote(cflags),
@@ -185,23 +208,23 @@ class CpythonTuner(MeasurementInterface):
             prefix=shlex.quote(prefix),
             configure_flags=self.args.configure_flags,
             jobs=self.args.jobs,
+            log=shlex.quote(logfile),
         )
-        cmd += " > {log} 2>&1".format(log=shlex.quote(logfile))
 
         log.info("building: CFLAGS=%s LDFLAGS=%s", cflags, ldflags)
         result = self.call_program(cmd, limit=self.args.build_timeout)
 
         if result["timeout"]:
-            log.error("build 超时: %s", self._tail(logfile))
+            log.error("build timed out: %s", self._tail(logfile))
             return None
         if result["returncode"] != 0:
-            log.error("build 失败 (returncode=%s):\n%s",
+            log.error("build failed (returncode=%s):\n%s",
                       result["returncode"], self._tail(logfile))
             return None
         return prefix
 
     def _find_python(self, prefix):
-        """在 install/bin 里找到编译出的 python3 可执行文件。"""
+        """Locate the built python3 executable under install/bin."""
         bin_dir = os.path.join(prefix, "bin")
         if not os.path.isdir(bin_dir):
             return None
@@ -218,10 +241,10 @@ class CpythonTuner(MeasurementInterface):
         return None
 
     # ------------------------------------------------------------------
-    # 运行 pyperformance 并解析分数
+    # Run pyperformance and parse the score
     # ------------------------------------------------------------------
     def _run_pyperformance(self, build_dir, python_bin, result_path):
-        """运行 pyperformance,返回 "OK" / "TIMEOUT" / "ERROR"。"""
+        """Run pyperformance; return "OK" / "TIMEOUT" / "ERROR"."""
         logfile = os.path.join(build_dir, "pyperformance.log")
 
         cmd = [
@@ -234,38 +257,39 @@ class CpythonTuner(MeasurementInterface):
         if self.args.benchmarks:
             cmd += ["-b", self.args.benchmarks]
 
-        # 在 build_dir 里运行,让 pyperformance 的 venv/ 落到 build_dir 下,
-        # 之后可以随 build_dir 一起清理。
+        # Run inside build_dir so pyperformance's venv/ lands under build_dir
+        # and can be cleaned up together with it.
         result = self.call_program(
             cmd, limit=self.args.run_timeout, cwd=build_dir)
 
-        # 把 stdout/stderr 落盘,方便排查单个配置的跑分情况。
+        # Persist stdout/stderr for troubleshooting individual runs.
         with open(logfile, "wb") as fd:
             fd.write(result.get("stdout") or b"")
             fd.write(b"\n")
             fd.write(result.get("stderr") or b"")
 
         if result["timeout"]:
-            log.error("pyperformance 超时: %s", self._tail(logfile))
+            log.error("pyperformance timed out: %s", self._tail(logfile))
             return "TIMEOUT"
         if result["returncode"] != 0:
-            log.error("pyperformance 失败 (returncode=%s):\n%s",
+            log.error("pyperformance failed (returncode=%s):\n%s",
                       result["returncode"], self._tail(logfile))
             return "ERROR"
         return "OK"
 
     def _parse_score(self, result_path):
-        """返回所有 benchmark 中位数的几何平均(秒),越小越快。"""
+        """Return the geometric mean of all benchmark medians (seconds)."""
         try:
             import pyperf
         except ImportError:
-            log.error("宿主机 python 缺少 pyperf,无法解析结果")
+            log.error("host python is missing pyperf, cannot parse results")
             return None
 
         try:
             suite = pyperf.BenchmarkSuite.load(result_path)
         except Exception as exc:  # noqa: BLE001
-            log.error("无法解析 pyperformance 结果 %s: %s", result_path, exc)
+            log.error("cannot parse pyperformance result %s: %s",
+                      result_path, exc)
             return None
 
         times = []
@@ -274,13 +298,13 @@ class CpythonTuner(MeasurementInterface):
             if median and median > 0:
                 times.append(median)
         if not times:
-            log.error("pyperformance 结果里没有有效的 benchmark 数据")
+            log.error("no valid benchmark data in pyperformance result")
             return None
 
         return math.exp(sum(math.log(t) for t in times) / len(times))
 
     # ------------------------------------------------------------------
-    # OpenTuner 入口:build + run
+    # OpenTuner entry point: build + run
     # ------------------------------------------------------------------
     def run(self, desired_result, input, limit):  # noqa: A002
         cfg = desired_result.configuration.data
@@ -293,21 +317,23 @@ class CpythonTuner(MeasurementInterface):
             build_dir, python_bin = cached
         else:
             build_dir = os.path.join(
-                self.args.build_root, "build-%d" % desired_result.id)
+                os.path.abspath(self.args.build_root),
+                "build-%d" % desired_result.id)
             prefix = self._build(build_dir, cflags, ldflags)
             if prefix is None:
                 return Result(state="ERROR", time=float("inf"))
 
             python_bin = self._find_python(prefix)
             if python_bin is None:
-                log.error("install 目录里找不到 python3 可执行文件")
+                log.error("could not find a python3 executable under install")
                 return Result(state="ERROR", time=float("inf"))
             self._build_cache[cache_key] = (build_dir, python_bin)
 
         result_path = os.path.join(build_dir, "pyperformance.json")
         status = self._run_pyperformance(build_dir, python_bin, result_path)
 
-        # 跑完清理 venv,节省磁盘(依赖已进 pip 缓存,重测同配置会重新安装)。
+        # Remove the venv after the run to save disk (deps are already in the
+        # pip cache and would just be reinstalled if the config is re-measured).
         venv_dir = os.path.join(build_dir, "venv")
         if not self.args.keep_venv and os.path.isdir(venv_dir):
             shutil.rmtree(venv_dir, ignore_errors=True)
@@ -323,7 +349,7 @@ class CpythonTuner(MeasurementInterface):
         return Result(time=score)
 
     # ------------------------------------------------------------------
-    # 结束时输出最优配置
+    # Emit the best configuration at the end of tuning
     # ------------------------------------------------------------------
     def save_final_config(self, configuration):
         cfg = configuration.data
@@ -339,7 +365,7 @@ class CpythonTuner(MeasurementInterface):
 
         with open(out_sh, "w") as fd:
             fd.write("#!/bin/sh\n")
-            fd.write("# 由 OpenTuner 自动调优得到的最优 CPython 编译/链接选项\n")
+            fd.write("# Best CPython compile/link options found by OpenTuner\n")
             fd.write("export CFLAGS=%s\n" % shlex.quote(cflags))
             fd.write("export LDFLAGS=%s\n" % shlex.quote(ldflags))
             fd.write(
@@ -348,14 +374,14 @@ class CpythonTuner(MeasurementInterface):
                 % (shlex.quote(self.args.source_dir),
                    self.args.configure_flags))
 
-        print("最优配置已写入:")
+        print("Best configuration written to:")
         print("  ", out_json)
         print("  ", out_sh)
         print("  CFLAGS =", cflags)
         print("  LDFLAGS =", ldflags)
 
     # ------------------------------------------------------------------
-    # 工具
+    # Utilities
     # ------------------------------------------------------------------
     @staticmethod
     def _tail(path, n=40):
@@ -370,37 +396,38 @@ class CpythonTuner(MeasurementInterface):
 def _add_args(argparser):
     argparser.add_argument(
         "--source-dir", default=os.path.expanduser("~/gerrit/cpython"),
-        help="CPython 源码目录(包含 configure)")
+        help="CPython source directory (containing configure)")
     argparser.add_argument(
         "--build-root", default="./builds",
-        help="构建目录,每个配置一个 build-<id> 子目录")
+        help="build directory, one build-<id> subdir per configuration")
     argparser.add_argument(
         "--pyperformance-python", default="python3",
-        help="用来运行 pyperformance 的宿主机 python(已装好 pyperformance)")
+        help="host python used to run pyperformance (must have it installed)")
     argparser.add_argument(
         "--configure-flags", default="--enable-optimizations --with-lto",
-        help="固定的 configure 参数(PGO/LTO 等)")
+        help="fixed configure flags (PGO/LTO, etc.)")
     argparser.add_argument(
         "--jobs", type=int, default=os.cpu_count(),
-        help="make -j 的并行度")
+        help="make -j parallelism")
     argparser.add_argument(
         "--benchmarks", default=None,
-        help="逗号分隔的 benchmark 列表,传给 pyperformance -b(默认全部)")
+        help="comma-separated benchmark list passed to pyperformance -b "
+             "(default: all)")
     argparser.add_argument(
         "--fast", action="store_true",
-        help="pyperformance 快速模式,缩短单次采样")
+        help="pyperformance fast mode, shorten each sample")
     argparser.add_argument(
         "--build-timeout", type=float, default=3600.0,
-        help="单次 build 的超时(秒)")
+        help="timeout for a single build (seconds)")
     argparser.add_argument(
         "--run-timeout", type=float, default=7200.0,
-        help="单次 pyperformance 跑分的超时(秒)")
+        help="timeout for a single pyperformance run (seconds)")
     argparser.add_argument(
         "--keep-venv", action="store_true",
-        help="跑完后保留 pyperformance 生成的 venv(默认删除以节省磁盘)")
+        help="keep the pyperformance venv after each run (removed by default)")
     argparser.add_argument(
         "--output-dir", default=".",
-        help="最优配置输出目录")
+        help="directory for the best-configuration output")
     return argparser
 
 

--- a/examples/cpython_pyperformance/cpython_pyperformance.py
+++ b/examples/cpython_pyperformance/cpython_pyperformance.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+使用 OpenTuner 自动调优 CPython 的 GCC 编译 / 链接选项,以 pyperformance 作为评测目标。
+
+原理
+----
+CPython 的 Makefile 里最终编译命令为::
+
+    $(CC) ... $(BASECFLAGS) $(OPT) $(CONFIGURE_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) ...
+    $(CC) ... $(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST) ...   # NODIST 部分在最后
+
+其中:
+* ``OPT``              由 ``--enable-optimizations`` 决定,实际是 ``-DNDEBUG -g -fwrapv -O3 -Wall``;
+* ``CONFIGURE_CFLAGS`` 就是你 configure 时通过环境变量 ``CFLAGS`` 传入的值;
+* ``CONFIGURE_LDFLAGS`` 同理来自环境变量 ``LDFLAGS``;
+* ``CONFIGURE_CFLAGS_NODIST`` / ``CONFIGURE_LDFLAGS_NODIST`` 里是 configure 自己追加的
+  ``-fno-semantic-interposition -flto -fuse-linker-plugin -ffat-lto-objects
+  -flto-partition=none`` 等(由 ``--with-lto`` 决定)。
+
+由于 ``CONFIGURE_CFLAGS`` 位于 ``OPT``(-O3)*之后*,所以在 ``CFLAGS`` 里放 ``-O2`` 会
+真正覆盖掉 ``-O3``;而我们想调优的 ``-f`` / ``--param`` / ``-march`` 选项也都放在
+``CFLAGS`` 里,位置同样在 NODIST 之前、不会和 LTO/PGO 冲突。
+
+注意:``-fno-semantic-interposition`` 和 ``-flto-partition=none`` 已经被
+``--with-lto`` / ``--enable-optimizations`` 固定追加到 NODIST 里,并且位于用户
+CFLAGS 之后,因此无法通过 CFLAGS 覆盖,本脚本也就不把它们列为可调参数。
+
+每个配置会:
+  1. 在独立的 build 目录里 configure + make + make install 出一个 python3.10;
+  2. 用宿主机上的 pyperformance 对刚编译出的解释器跑基准;
+  3. 读取 pyperformance 输出的 JSON,取所有 benchmark 中位数的几何平均作为分数
+     (越小越快),返回给 OpenTuner。
+
+用法示例
+--------
+    python3 cpython_pyperformance.py \
+        --source-dir ~/gerrit/cpython \
+        --build-root ./builds \
+        --pyperformance-python python3 \
+        --benchmarks 2to3,chameleon,django_template,json_loads,regex_compile \
+        --fast \
+        --jobs 16 \
+        --parallelism 1 \
+        --test-limit 200
+
+说明:
+* ``--fast``            让 pyperformance 用快速模式(每项只测一个值),大幅缩短单次采样;
+* ``--benchmarks``      只跑一小批有代表性的 benchmark,进一步缩短采样时间;
+* ``--test-limit N``    调优到第 N 个采样后停止(本 fork 里是“采样个数”,不是超时);
+                        也可用 ``--stop-after SECONDS`` 按墙钟时间停止;
+* ``--parallelism 1``   一次只 build 一个配置,避免并行 make 互相抢占 CPU;
+* 单个配置的 build / 跑分超时由 ``--build-timeout`` / ``--run-timeout`` 控制
+  (本 fork 的 ``--test-limit`` 已不再是单次超时,见上);
+* 中断后重新运行会自动续跑(结果保存在 opentuner.db 里)。
+* 每个配置的依赖会装到各自 venv 里,但 pip 会命中本地缓存,不会重复联网下载;
+  跑完默认删除 venv 以节省磁盘,可用 ``--keep-venv`` 保留。
+"""
+
+from __future__ import print_function
+
+import json
+import logging
+import math
+import os
+import shlex
+import shutil
+
+import opentuner
+from opentuner import ConfigurationManipulator
+from opentuner import EnumParameter
+from opentuner import IntegerParameter
+from opentuner import MeasurementInterface
+from opentuner import Result
+
+log = logging.getLogger("cpython_pyperformance")
+
+
+# ---------------------------------------------------------------------------
+# 可调优的 GCC -f 编译选项。
+# 每个选项取值 on / off / default:
+#   on       -> -f<flag>
+#   off      -> -fno-<flag>
+#   default  -> 不显式指定(交给 -O3 的默认行为)
+# 这里刻意只挑了对 CPython 性能可能有影响、且 -fno- 形式都合法的选项,避免构建失败。
+# ---------------------------------------------------------------------------
+COMPILE_FLAGS = [
+    "funroll-loops",
+    "fipa-pta",
+    "ftree-vectorize",
+    "fomit-frame-pointer",
+    "fpredictive-commoning",
+    "fgcse-after-reload",
+    "freorder-blocks-and-partition",
+    "fdevirtualize-speculatively",
+    "fgraphite-identity",
+    "ftracer",
+    "ftree-loop-distribute-patterns",
+    "finline-functions",
+]
+
+# (名字, 最小值, 最大值) 的 GCC --param 参数。
+GCC_PARAMS = [
+    ("early-inlining-insns", 0, 300),
+    ("inline-unit-growth", 0, 100),
+    ("max-inline-insns-auto", 0, 100),
+    ("predictable-branch-outcome", 0, 100),
+]
+
+
+class CpythonTuner(MeasurementInterface):
+    def __init__(self, *pargs, **kwargs):
+        kwargs.setdefault("program_name", "cpython")
+        super(CpythonTuner, self).__init__(*pargs, **kwargs)
+        # 以 (cflags, ldflags) 为 key 的构建缓存,避免同一配置重复 build。
+        self._build_cache = {}
+
+    # ------------------------------------------------------------------
+    # 搜索空间
+    # ------------------------------------------------------------------
+    def manipulator(self):
+        manipulator = ConfigurationManipulator()
+
+        # 优化等级。放在 CFLAGS 里,位置在 OPT(-O3) 之后,可以真正覆盖它。
+        manipulator.add_parameter(EnumParameter("opt", ["-O2", "-O3"]))
+        # 是否针对本机 CPU 微架构(-march=native / -mtune=native)。
+        manipulator.add_parameter(EnumParameter("march", ["default", "native"]))
+
+        for flag in COMPILE_FLAGS:
+            manipulator.add_parameter(
+                EnumParameter(flag, ["on", "off", "default"]))
+
+        for param, lo, hi in GCC_PARAMS:
+            manipulator.add_parameter(IntegerParameter(param, lo, hi))
+
+        return manipulator
+
+    # ------------------------------------------------------------------
+    # 把配置转成 CFLAGS / LDFLAGS 字符串
+    # ------------------------------------------------------------------
+    def _cfg_to_cflags(self, cfg):
+        flags = [cfg["opt"]]
+        if cfg["march"] == "native":
+            flags += ["-march=native", "-mtune=native"]
+
+        for flag in COMPILE_FLAGS:
+            value = cfg[flag]
+            if value == "on":
+                flags.append("-f" + flag)
+            elif value == "off":
+                flags.append("-fno-" + flag)
+
+        for param, _lo, _hi in GCC_PARAMS:
+            flags.append("--param=%s=%d" % (param, cfg[param]))
+
+        return " ".join(flags)
+
+    def _cfg_to_ldflags(self, cfg):
+        # 链接阶段目前没有额外可调项(如需,可在此扩展,例如 -Wl,-O1 等)。
+        return ""
+
+    # ------------------------------------------------------------------
+    # 构建 CPython
+    # ------------------------------------------------------------------
+    def _build(self, build_dir, cflags, ldflags):
+        prefix = os.path.join(build_dir, "install")
+        configure = os.path.join(self.args.source_dir, "configure")
+        logfile = os.path.join(build_dir, "build.log")
+
+        os.makedirs(build_dir, exist_ok=True)
+
+        cmd = (
+            "set -e; "
+            "cd {build_dir}; "
+            "export CFLAGS={cflags}; "
+            "export LDFLAGS={ldflags}; "
+            "{configure} --prefix={prefix} {configure_flags}; "
+            "make -j{jobs}; "
+            "make install"
+        ).format(
+            build_dir=shlex.quote(build_dir),
+            cflags=shlex.quote(cflags),
+            ldflags=shlex.quote(ldflags),
+            configure=shlex.quote(configure),
+            prefix=shlex.quote(prefix),
+            configure_flags=self.args.configure_flags,
+            jobs=self.args.jobs,
+        )
+        cmd += " > {log} 2>&1".format(log=shlex.quote(logfile))
+
+        log.info("building: CFLAGS=%s LDFLAGS=%s", cflags, ldflags)
+        result = self.call_program(cmd, limit=self.args.build_timeout)
+
+        if result["timeout"]:
+            log.error("build 超时: %s", self._tail(logfile))
+            return None
+        if result["returncode"] != 0:
+            log.error("build 失败 (returncode=%s):\n%s",
+                      result["returncode"], self._tail(logfile))
+            return None
+        return prefix
+
+    def _find_python(self, prefix):
+        """在 install/bin 里找到编译出的 python3 可执行文件。"""
+        bin_dir = os.path.join(prefix, "bin")
+        if not os.path.isdir(bin_dir):
+            return None
+        candidates = sorted(
+            f for f in os.listdir(bin_dir)
+            if f.startswith("python3.") and "config" not in f
+        )
+        if candidates:
+            return os.path.join(bin_dir, candidates[0])
+        for name in ("python3", "python"):
+            path = os.path.join(bin_dir, name)
+            if os.path.exists(path):
+                return path
+        return None
+
+    # ------------------------------------------------------------------
+    # 运行 pyperformance 并解析分数
+    # ------------------------------------------------------------------
+    def _run_pyperformance(self, build_dir, python_bin, result_path):
+        """运行 pyperformance,返回 "OK" / "TIMEOUT" / "ERROR"。"""
+        logfile = os.path.join(build_dir, "pyperformance.log")
+
+        cmd = [
+            self.args.pyperformance_python, "-m", "pyperformance", "run",
+            "--python", python_bin,
+            "-o", result_path,
+        ]
+        if self.args.fast:
+            cmd.append("-f")
+        if self.args.benchmarks:
+            cmd += ["-b", self.args.benchmarks]
+
+        # 在 build_dir 里运行,让 pyperformance 的 venv/ 落到 build_dir 下,
+        # 之后可以随 build_dir 一起清理。
+        result = self.call_program(
+            cmd, limit=self.args.run_timeout, cwd=build_dir)
+
+        # 把 stdout/stderr 落盘,方便排查单个配置的跑分情况。
+        with open(logfile, "wb") as fd:
+            fd.write(result.get("stdout") or b"")
+            fd.write(b"\n")
+            fd.write(result.get("stderr") or b"")
+
+        if result["timeout"]:
+            log.error("pyperformance 超时: %s", self._tail(logfile))
+            return "TIMEOUT"
+        if result["returncode"] != 0:
+            log.error("pyperformance 失败 (returncode=%s):\n%s",
+                      result["returncode"], self._tail(logfile))
+            return "ERROR"
+        return "OK"
+
+    def _parse_score(self, result_path):
+        """返回所有 benchmark 中位数的几何平均(秒),越小越快。"""
+        try:
+            import pyperf
+        except ImportError:
+            log.error("宿主机 python 缺少 pyperf,无法解析结果")
+            return None
+
+        try:
+            suite = pyperf.BenchmarkSuite.load(result_path)
+        except Exception as exc:  # noqa: BLE001
+            log.error("无法解析 pyperformance 结果 %s: %s", result_path, exc)
+            return None
+
+        times = []
+        for bench in suite.get_benchmarks():
+            median = bench.median()
+            if median and median > 0:
+                times.append(median)
+        if not times:
+            log.error("pyperformance 结果里没有有效的 benchmark 数据")
+            return None
+
+        return math.exp(sum(math.log(t) for t in times) / len(times))
+
+    # ------------------------------------------------------------------
+    # OpenTuner 入口:build + run
+    # ------------------------------------------------------------------
+    def run(self, desired_result, input, limit):  # noqa: A002
+        cfg = desired_result.configuration.data
+        cflags = self._cfg_to_cflags(cfg)
+        ldflags = self._cfg_to_ldflags(cfg)
+
+        cache_key = (cflags, ldflags)
+        cached = self._build_cache.get(cache_key)
+        if cached is not None:
+            build_dir, python_bin = cached
+        else:
+            build_dir = os.path.join(
+                self.args.build_root, "build-%d" % desired_result.id)
+            prefix = self._build(build_dir, cflags, ldflags)
+            if prefix is None:
+                return Result(state="ERROR", time=float("inf"))
+
+            python_bin = self._find_python(prefix)
+            if python_bin is None:
+                log.error("install 目录里找不到 python3 可执行文件")
+                return Result(state="ERROR", time=float("inf"))
+            self._build_cache[cache_key] = (build_dir, python_bin)
+
+        result_path = os.path.join(build_dir, "pyperformance.json")
+        status = self._run_pyperformance(build_dir, python_bin, result_path)
+
+        # 跑完清理 venv,节省磁盘(依赖已进 pip 缓存,重测同配置会重新安装)。
+        venv_dir = os.path.join(build_dir, "venv")
+        if not self.args.keep_venv and os.path.isdir(venv_dir):
+            shutil.rmtree(venv_dir, ignore_errors=True)
+
+        if status != "OK":
+            return Result(state=status, time=float("inf"))
+
+        score = self._parse_score(result_path)
+        if score is None:
+            return Result(state="ERROR", time=float("inf"))
+
+        log.info("score (geomean of medians) = %.4f s", score)
+        return Result(time=score)
+
+    # ------------------------------------------------------------------
+    # 结束时输出最优配置
+    # ------------------------------------------------------------------
+    def save_final_config(self, configuration):
+        cfg = configuration.data
+        cflags = self._cfg_to_cflags(cfg)
+        ldflags = self._cfg_to_ldflags(cfg)
+
+        os.makedirs(self.args.output_dir, exist_ok=True)
+        out_json = os.path.join(self.args.output_dir, "best_config.json")
+        out_sh = os.path.join(self.args.output_dir, "best_flags.sh")
+
+        with open(out_json, "w") as fd:
+            json.dump(cfg, fd, indent=2, sort_keys=True)
+
+        with open(out_sh, "w") as fd:
+            fd.write("#!/bin/sh\n")
+            fd.write("# 由 OpenTuner 自动调优得到的最优 CPython 编译/链接选项\n")
+            fd.write("export CFLAGS=%s\n" % shlex.quote(cflags))
+            fd.write("export LDFLAGS=%s\n" % shlex.quote(ldflags))
+            fd.write(
+                "cd build/best && %s/configure --prefix=$PWD/install %s && "
+                "make -j && make install\n"
+                % (shlex.quote(self.args.source_dir),
+                   self.args.configure_flags))
+
+        print("最优配置已写入:")
+        print("  ", out_json)
+        print("  ", out_sh)
+        print("  CFLAGS =", cflags)
+        print("  LDFLAGS =", ldflags)
+
+    # ------------------------------------------------------------------
+    # 工具
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _tail(path, n=40):
+        try:
+            with open(path, "rb") as fd:
+                lines = fd.readlines()
+            return b"".join(lines[-n:]).decode("utf-8", "replace")
+        except Exception:  # noqa: BLE001
+            return ""
+
+
+def _add_args(argparser):
+    argparser.add_argument(
+        "--source-dir", default=os.path.expanduser("~/gerrit/cpython"),
+        help="CPython 源码目录(包含 configure)")
+    argparser.add_argument(
+        "--build-root", default="./builds",
+        help="构建目录,每个配置一个 build-<id> 子目录")
+    argparser.add_argument(
+        "--pyperformance-python", default="python3",
+        help="用来运行 pyperformance 的宿主机 python(已装好 pyperformance)")
+    argparser.add_argument(
+        "--configure-flags", default="--enable-optimizations --with-lto",
+        help="固定的 configure 参数(PGO/LTO 等)")
+    argparser.add_argument(
+        "--jobs", type=int, default=os.cpu_count(),
+        help="make -j 的并行度")
+    argparser.add_argument(
+        "--benchmarks", default=None,
+        help="逗号分隔的 benchmark 列表,传给 pyperformance -b(默认全部)")
+    argparser.add_argument(
+        "--fast", action="store_true",
+        help="pyperformance 快速模式,缩短单次采样")
+    argparser.add_argument(
+        "--build-timeout", type=float, default=3600.0,
+        help="单次 build 的超时(秒)")
+    argparser.add_argument(
+        "--run-timeout", type=float, default=7200.0,
+        help="单次 pyperformance 跑分的超时(秒)")
+    argparser.add_argument(
+        "--keep-venv", action="store_true",
+        help="跑完后保留 pyperformance 生成的 venv(默认删除以节省磁盘)")
+    argparser.add_argument(
+        "--output-dir", default=".",
+        help="最优配置输出目录")
+    return argparser
+
+
+if __name__ == "__main__":
+    opentuner.init_logging()
+    argparser = opentuner.default_argparser()
+    argparser = _add_args(argparser)
+    CpythonTuner.main(argparser.parse_args())


### PR DESCRIPTION
Add cpython_pyperformance example for tuning CPython GCC flags

Autotune CPython's compiler/linker options using pyperformance as the
objective. For each configuration the example builds CPython out-of-tree
with the tuned CFLAGS/LDFLAGS and a fixed --enable-optimizations --with-lto,
runs pyperformance on the resulting interpreter, and returns the geometric
mean of all benchmark medians as the score.

Search space: -O2/-O3, -march=native, 12 -f flags, 4 --param values.

#186 


Testing

- [x] python3 -m py_compile examples/cpython_pyperformance/cpython_pyperformance.py
- [x] python3 examples/cpython_pyperformance/cpython_pyperformance.py --help
- [x] Score parsing verified against a real pyperformance output (result-default.json, 107 benchmarks).